### PR TITLE
FEAT: 카카오 로그인 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### .env files ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  db:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_DB: lightrip
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: rhkrwogus1!
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/Auth.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/Auth.java
@@ -1,0 +1,49 @@
+package com.kauniv.lightrip.domain.user.entity;
+
+import com.kauniv.lightrip.global.oauth.SocialType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "auth",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"social_id", "social_type"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class Auth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "auth_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "social_id", nullable = false, length = 50)
+    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type", nullable = false)
+    private SocialType socialType;
+
+    @Column(name = "refresh_token", columnDefinition = "TEXT")
+    private String refreshToken;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/CurrentMode.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/CurrentMode.java
@@ -1,0 +1,6 @@
+package com.kauniv.lightrip.domain.user.entity;
+
+public enum CurrentMode {
+    INDIVIDUAL, // 개인 모드
+    TEAM // 팀 모드
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
@@ -1,0 +1,43 @@
+package com.kauniv.lightrip.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @Column(name = "email", length = 50)
+    private String email;
+
+    @Column(name = "profile_img", columnDefinition = "TEXT")
+    private String profileImg;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_mode")
+    private CurrentMode currentMode;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/repository/AuthRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/repository/AuthRepository.java
@@ -1,0 +1,13 @@
+package com.kauniv.lightrip.domain.user.repository;
+
+import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.global.oauth.SocialType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthRepository extends JpaRepository<Auth, Long> {
+
+    Optional<Auth> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+    Optional<Auth> findByUser_IdAndSocialType(Long userId, SocialType socialType);
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.kauniv.lightrip.domain.user.repository;
+
+import com.kauniv.lightrip.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -1,9 +1,9 @@
 package com.kauniv.lightrip.domain.user.service;
 
-import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.global.auth.entity.Auth;
 import com.kauniv.lightrip.domain.user.entity.CurrentMode;
 import com.kauniv.lightrip.domain.user.entity.User;
-import com.kauniv.lightrip.domain.user.repository.AuthRepository;
+import com.kauniv.lightrip.global.auth.repository.AuthRepository;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.oauth.SocialType;
 import com.kauniv.lightrip.global.oauth.userinfo.OAuth2UserInfo;

--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -1,0 +1,45 @@
+package com.kauniv.lightrip.domain.user.service;
+
+import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.domain.user.entity.CurrentMode;
+import com.kauniv.lightrip.domain.user.entity.User;
+import com.kauniv.lightrip.domain.user.repository.AuthRepository;
+import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.oauth.SocialType;
+import com.kauniv.lightrip.global.oauth.userinfo.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final AuthRepository authRepository;
+
+    public Auth findOrCreateUser(OAuth2UserInfo oAuth2UserInfo, SocialType socialType) {
+        return authRepository
+                .findBySocialIdAndSocialType(oAuth2UserInfo.getProviderId(), socialType)
+                .orElseGet(() -> createUser(oAuth2UserInfo, socialType));
+    }
+
+    private Auth createUser(OAuth2UserInfo oAuth2UserInfo, SocialType socialType) {
+        User user = userRepository.save(
+                User.builder()
+                        .nickname(oAuth2UserInfo.getNickname())
+                        .email(oAuth2UserInfo.getEmail())
+                        .currentMode(CurrentMode.INDIVIDUAL)
+                        .build()
+        );
+
+        return authRepository.save(
+                Auth.builder()
+                        .user(user)
+                        .socialId(oAuth2UserInfo.getProviderId())
+                        .socialType(socialType)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
@@ -1,0 +1,41 @@
+package com.kauniv.lightrip.global.auth.controller;
+
+import com.kauniv.lightrip.global.auth.dto.TokenResponse;
+import com.kauniv.lightrip.global.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(
+            @RequestHeader("Refresh-Token") String refreshToken) {
+        String newAccessToken = authService.reissueAccessToken(refreshToken);
+        return ResponseEntity.ok(
+                TokenResponse.builder()
+                        .accessToken(newAccessToken)
+                        .build()
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal Long userId) {
+        authService.logout(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal Long userId) {
+        authService.withdraw(userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/auth/dto/LoginResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.kauniv.lightrip.global.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/kauniv/lightrip/global/auth/dto/TokenResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/dto/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.kauniv.lightrip.global.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/kauniv/lightrip/global/auth/entity/Auth.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/entity/Auth.java
@@ -1,5 +1,6 @@
-package com.kauniv.lightrip.domain.user.entity;
+package com.kauniv.lightrip.global.auth.entity;
 
+import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.global.oauth.SocialType;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/kauniv/lightrip/global/auth/repository/AuthRepository.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/repository/AuthRepository.java
@@ -1,6 +1,6 @@
-package com.kauniv.lightrip.domain.user.repository;
+package com.kauniv.lightrip.global.auth.repository;
 
-import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.global.auth.entity.Auth;
 import com.kauniv.lightrip.global.oauth.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,5 +9,9 @@ import java.util.Optional;
 public interface AuthRepository extends JpaRepository<Auth, Long> {
 
     Optional<Auth> findBySocialIdAndSocialType(String socialId, SocialType socialType);
+    Optional<Auth> findByUser_Id(Long userId);
     Optional<Auth> findByUser_IdAndSocialType(Long userId, SocialType socialType);
+
+    void deleteByUser_Id(Long userId);
+
 }

--- a/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
@@ -1,0 +1,48 @@
+package com.kauniv.lightrip.global.auth.service;
+
+import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.auth.entity.Auth;
+import com.kauniv.lightrip.global.auth.repository.AuthRepository;
+import com.kauniv.lightrip.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final AuthRepository authRepository;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    public String reissueAccessToken(String refreshToken) {
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new RuntimeException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        Long userId = jwtProvider.getUserId(refreshToken);
+
+        Auth auth = authRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new RuntimeException("Auth를 찾을 수 없습니다."));
+
+        if (!auth.getRefreshToken().equals(refreshToken)) {
+            throw new RuntimeException("리프레시 토큰이 일치하지 않습니다.");
+        }
+
+        return jwtProvider.generateAccessToken(userId);
+    }
+
+    public void logout(Long userId) {
+        Auth auth = authRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new RuntimeException("Auth를 찾을 수 없습니다."));
+
+        auth.updateRefreshToken(null);
+    }
+
+    public void withdraw(Long userId) {
+        authRepository.deleteByUser_Id(userId);
+        userRepository.deleteById(userId);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.kauniv.lightrip.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kauniv.lightrip.global.jwt.JwtFilter;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
 import com.kauniv.lightrip.global.oauth.CustomOAuth2UserService;
@@ -30,7 +31,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .requestMatchers("/", "/oauth2/**", "/login/**", "/auth/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
@@ -46,4 +47,10 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
 }

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.kauniv.lightrip.global.config;
+
+import com.kauniv.lightrip.global.jwt.JwtFilter;
+import com.kauniv.lightrip.global.jwt.JwtProvider;
+import com.kauniv.lightrip.global.oauth.CustomOAuth2UserService;
+import com.kauniv.lightrip.global.oauth.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        .successHandler(oAuth2SuccessHandler)
+                )
+                .addFilterBefore(
+                        new JwtFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/jwt/JwtFilter.java
+++ b/src/main/java/com/kauniv/lightrip/global/jwt/JwtFilter.java
@@ -1,0 +1,55 @@
+package com.kauniv.lightrip.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                    );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/jwt/JwtProvider.java
+++ b/src/main/java/com/kauniv/lightrip/global/jwt/JwtProvider.java
@@ -1,0 +1,68 @@
+package com.kauniv.lightrip.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return Long.valueOf(claims.getSubject());
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2User.java
@@ -1,6 +1,6 @@
 package com.kauniv.lightrip.global.oauth;
 
-import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.global.auth.entity.Auth;
 import com.kauniv.lightrip.global.oauth.userinfo.OAuth2UserInfo;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2User.java
@@ -1,0 +1,55 @@
+package com.kauniv.lightrip.global.oauth;
+
+import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.global.oauth.userinfo.OAuth2UserInfo;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Auth auth;
+    private final OAuth2UserInfo oAuth2UserInfo;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(Auth auth, OAuth2UserInfo oAuth2UserInfo, Map<String, Object> attributes) {
+        this.auth = auth;
+        this.oAuth2UserInfo = oAuth2UserInfo;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return oAuth2UserInfo.getProviderId();
+    }
+
+    public Long getUserId() {
+        return auth.getUser().getId();
+    }
+
+    public String getEmail() {
+        return oAuth2UserInfo.getEmail();
+    }
+
+    public String getNickname() {
+        return oAuth2UserInfo.getNickname();
+    }
+
+    public SocialType getSocialType() {
+        return auth.getSocialType();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2UserService.java
@@ -1,6 +1,6 @@
 package com.kauniv.lightrip.global.oauth;
 
-import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.global.auth.entity.Auth;
 import com.kauniv.lightrip.domain.user.service.UserService;
 import com.kauniv.lightrip.global.oauth.userinfo.KakaoOAuth2UserInfo;
 import com.kauniv.lightrip.global.oauth.userinfo.OAuth2UserInfo;

--- a/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,44 @@
+package com.kauniv.lightrip.global.oauth;
+
+import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.domain.user.service.UserService;
+import com.kauniv.lightrip.global.oauth.userinfo.KakaoOAuth2UserInfo;
+import com.kauniv.lightrip.global.oauth.userinfo.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserService userService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // OAuth2 제공자로부터 사용자 정보 가져오기
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // 제공자 이름 가져오기 (kakao)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2UserInfo oAuth2UserInfo;
+
+        // 카카오 사용자 정보 파싱 - 추후 다른 제공자 추가 시 분기 예정
+        if (registrationId.equals("kakao")) {
+            oAuth2UserInfo = new KakaoOAuth2UserInfo(oAuth2User.getAttributes());
+        } else {
+            throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + registrationId);
+        }
+
+        SocialType socialType = SocialType.valueOf(registrationId.toUpperCase());
+
+        Auth auth = userService.findOrCreateUser(oAuth2UserInfo, socialType);
+
+        // CustomOAuth2User 반환
+        return new CustomOAuth2User(auth, oAuth2UserInfo, oAuth2User.getAttributes());
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
@@ -1,7 +1,9 @@
 package com.kauniv.lightrip.global.oauth;
 
-import com.kauniv.lightrip.domain.user.entity.Auth;
-import com.kauniv.lightrip.domain.user.repository.AuthRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kauniv.lightrip.global.auth.dto.LoginResponse;
+import com.kauniv.lightrip.global.auth.entity.Auth;
+import com.kauniv.lightrip.global.auth.repository.AuthRepository;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -19,6 +21,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JwtProvider jwtProvider;
     private final AuthRepository authRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
@@ -40,9 +43,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         auth.updateRefreshToken(refreshToken);
 
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write(
-                "{\"accessToken\":\"" + accessToken + "\"," +
-                        "\"refreshToken\":\"" + refreshToken + "\"}"
-        );
+
+        LoginResponse loginResponse = LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(loginResponse));
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,48 @@
+package com.kauniv.lightrip.global.oauth;
+
+import com.kauniv.lightrip.domain.user.entity.Auth;
+import com.kauniv.lightrip.domain.user.repository.AuthRepository;
+import com.kauniv.lightrip.global.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final AuthRepository authRepository;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        Long userId = oAuth2User.getUserId();
+        SocialType socialType = oAuth2User.getSocialType();
+
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String refreshToken = jwtProvider.generateRefreshToken(userId);
+
+        Auth auth = authRepository.findByUser_IdAndSocialType(userId, socialType)
+                .orElseThrow(() -> new RuntimeException("Auth를 찾을 수 없습니다."));
+        auth.updateRefreshToken(refreshToken);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                "{\"accessToken\":\"" + accessToken + "\"," +
+                        "\"refreshToken\":\"" + refreshToken + "\"}"
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/SocialType.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/SocialType.java
@@ -1,0 +1,6 @@
+package com.kauniv.lightrip.global.oauth;
+
+public enum SocialType {
+    KAKAO,
+    GOOGLE
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/userinfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.kauniv.lightrip.global.oauth.userinfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+    private final String providerId;
+    private final String email;
+    private final String nickname;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.providerId = String.valueOf(attributes.get("id"));
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.email = (String) kakaoAccount.get("email");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        this.nickname = (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getProviderId() {
+        return providerId;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,7 @@
+package com.kauniv.lightrip.global.oauth.userinfo;
+
+public interface OAuth2UserInfo {
+        String getProviderId(); // OAuth2 제공자에서 고유한 사용자 ID
+        String getEmail(); // 이메일
+        String getNickname(); // 닉네임
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,16 @@
 spring.application.name=lightrip
+
+# Registration: ? ???? ??? ??
+spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_REST_API_KEY}
+spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
+spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname, account_email
+
+# Provider: ??? API ?? ??
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,23 @@ spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kak
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# jwt
+jwt.secret=${JWT_SECRET}
+jwt.access-token-expiration=3600000
+jwt.refresh-token-expiration=1209600000
+
+# PostgreSQL ??
+spring.datasource.url=jdbc:postgresql://localhost:5432/lightrip
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA ??
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Flyway ?? ????
+spring.flyway.enabled=false


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
> Closes #1

## 📝 작업 내용

> 카카오 로그인 API 구현

### 주요 기능
- [x] 카카오 OAuth2 로그인 구현
- [x] JWT 액세스/리프레시 토큰 발급
- [x] 토큰 재발급 API 구현 (POST /auth/refresh)
- [x] 로그아웃 API 구현 (POST /auth/logout)
- [x] 회원탈퇴 API 구현 (DELETE /auth/withdraw)

### 설정/구조 변경
- [x] Auth 엔티티 및 Repository를 global/auth로 분리
- [x] LoginResponse, TokenResponse DTO 추가
- [x] Docker 기반 로컬 PostgreSQL 환경 구성

### 테스트 결과
- [x] 카카오 로그인 후 JWT 발급 확인
- [x] 토큰 재발급, 로그아웃, 회원탈퇴 API 테스트 예정

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

