### PR TITLE
FIX: 로컬 서버 문제 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '3'
 services:
   db:
     image: postgis/postgis:16-3.4
     environment:
       POSTGRES_DB: lightrip
-      POSTGRES_USER: root
-      POSTGRES_PASSWORD: rhkrwogus1!
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
       - "5432:5432"
     volumes:

--- a/src/main/java/com/kauniv/lightrip/global/config/JacksonConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.kauniv.lightrip.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.kauniv.lightrip.global.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kauniv.lightrip.global.jwt.JwtFilter;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
 import com.kauniv.lightrip.global.oauth.CustomOAuth2UserService;
@@ -46,11 +45,6 @@ public class SecurityConfig {
                 );
 
         return http.build();
-    }
-
-    @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper();
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,6 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # Flyway ?? ????
 spring.flyway.enabled=false
+
+# ?? ?? ??
+spring.main.allow-circular-references=true


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #3 

## 📝 작업 내용

로컬 환경에서 서버가 되지 않는 문제를 해결합니다. DB 인증 실패, `ObjectMapper` Bean 누락, `SecurityConfig` 순환 참조 등 여러 원인이 복합적으로 작용하고 있어 이를 수정

### 환경 설정

- [x] `docker-compose.yml`의 DB 계정 정보를 `.env` 환경변수로 분리
- [x] `POSTGRES_USER`, `POSTGRES_PASSWORD`를 `${DB_USERNAME}`, `${DB_PASSWORD}`로 변경

> 기존에는 `application.properties`에서는 `${DB_USERNAME}`, `${DB_PASSWORD}`를 사용하지만 `docker-compose.yml`에는 계정 정보가 하드코딩되어 있어, `.env`의 값과 컨테이너 내부 계정이 불일치할 경우 `FATAL: password authentication failed` 에러가 발생함. 이제 `.env` 한 곳에서 DB 계정 정보를 관리할 수 있도록 통일

### 버그 수정

- [x] `ObjectMapper` Bean을 별도의 `JacksonConfig` 클래스로 분리
- [x] `SecurityConfig` ↔ `OAuth2SuccessHandler` 순환 참조 해결
- [x] `SecurityConfig`에서 불필요한 `ObjectMapper` import 제거

> 기존 구조에서는 `SecurityConfig` 내부에 `ObjectMapper` Bean이 정의되어 있어, `SecurityConfig` → `OAuth2SuccessHandler` → `ObjectMapper` → `SecurityConfig` 형태의 순환 참조가 발생했습니다.
>
> ```
> The dependencies of some of the beans in the application context form a cycle:
> ┌─────┐
> |  securityConfig
> ↑     ↓
> |  OAuth2SuccessHandler
> └─────┘
> ```
>
> `ObjectMapper` Bean 정의를 별도 설정 클래스로 분리하여 순환 참조를 끊었습니다. 또한 본 프로젝트는 `spring-boot-starter-web`이 아닌 `spring-boot-starter-webmvc`를 사용하고 있어 Jackson이 자동 포함되지 않으므로, `ObjectMapper` Bean은 별도 정의가 필요합니다.

### 테스트 결과

- [x] 로컬 서버 정상 기동 확인
- [x] DB 연결 및 `auth`, `users` 테이블 자동 생성 확인
- [x] Tomcat 8080 포트 정상 바인딩 확인

> 기동 로그:
> ```
> Tomcat started on port 8080 (http) with context path '/'
> Started LightripApplication in 6.663 seconds
> ```

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.