### PR TITLE
FEAT: 전역 예외 처리 및 Swagger 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/BusinessException.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.kauniv.lightrip.global.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -1,0 +1,47 @@
+package com.kauniv.lightrip.global.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ===== Common =====
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "허용되지 않은 메서드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부 오류가 발생했습니다."),
+    HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C004", "접근이 거부되었습니다."),
+
+    // ===== Auth =====
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
+
+    // ===== User =====
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),
+
+    // ===== Passport =====
+    PASSPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 여권입니다."),
+    PASSPORT_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "해당 여권에 대한 권한이 없습니다."),
+    PASSPORT_DUPLICATE(HttpStatus.CONFLICT, "P003", "같은 장소, 같은 날짜에 이미 등록된 여권이 있습니다."),
+    PASSPORT_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "P004", "방문 인증에 실패했습니다."),
+
+    // ===== Scrap =====
+    SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "스크랩 기록이 존재하지 않습니다."),
+    SCRAP_DUPLICATE(HttpStatus.CONFLICT, "S002", "이미 스크랩한 여권입니다."),
+    SCRAP_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "S003", "본인의 여권은 스크랩할 수 없습니다."),
+
+    // ===== Team =====
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "존재하지 않는 팀입니다."),
+    TEAM_ALREADY_JOINED(HttpStatus.CONFLICT, "T002", "이미 가입된 팀이 있습니다."),
+    TEAM_INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "T003", "유효하지 않은 초대 코드입니다."),
+
+    // ===== Map =====
+    REVERSE_GEOCODE_FAILED(HttpStatus.BAD_GATEWAY, "M001", "역지오코딩에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.kauniv.lightrip.global.common.exception;
+
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /** 비즈니스 예외 */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        ErrorCode code = e.getErrorCode();
+        log.warn("[BusinessException] {} - {}", code.getCode(), e.getMessage());
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ApiResponse.error(code, e.getMessage()));
+    }
+
+    /** @Valid 검증 실패 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        String detail = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("[ValidationException] {}", detail);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, detail));
+    }
+
+    /** 잘못된 HTTP 메서드 */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        log.warn("[MethodNotAllowed] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(ApiResponse.error(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    /** Spring Security 인가 실패 */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(AccessDeniedException e) {
+        log.warn("[AccessDenied] {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.HANDLE_ACCESS_DENIED.getStatus())
+                .body(ApiResponse.error(ErrorCode.HANDLE_ACCESS_DENIED));
+    }
+
+    /** 그 외 모든 예외 (최후의 보루) */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("[UnhandledException]", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/common/response/ApiResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/response/ApiResponse.java
@@ -1,0 +1,42 @@
+package com.kauniv.lightrip.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(boolean success, String code, String message, T data) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, "SUCCESS", "요청이 성공했습니다.", data);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, "SUCCESS", message, data);
+    }
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>(true, "SUCCESS", "요청이 성공했습니다.", null);
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode, String overrideMessage) {
+        return new ApiResponse<>(false, errorCode.getCode(), overrideMessage, null);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -30,7 +30,10 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login/**", "/auth/refresh", "/actuator/health").permitAll()
+                        .requestMatchers(
+                                "/", "/oauth2/**", "/login/**", "/auth/refresh",
+                                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/kauniv/lightrip/global/config/SwaggerConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.kauniv.lightrip.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "BearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, bearerAuthSecurityScheme()));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("LighTrip API")
+                .description("LighTrip 서비스의 API 명세서입니다.")
+                .version("v1.0.0");
+    }
+
+    private SecurityScheme bearerAuthSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,6 @@ spring.flyway.enabled=${FLYWAY_ENABLED:false}
 
 # ??
 spring.main.allow-circular-references=true
+
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #9 

## 📝 작업 내용
### 공통 응답 포맷
- `ApiResponse<T>` 도입: 성공/실패 응답 구조 통일 (`success`, `code`, `message`, `data`)
- `@JsonInclude(NON_NULL)`로 data 없을 때 응답 처리

### 전역 예외 처리
- `ErrorCode` enum: 도메인별 prefix로 코드 체계화 (C/A/U/P/S/T/M)
- `BusinessException`: 단일 런타임 예외로 도메인 예외 통합 관리
- `GlobalExceptionHandler`: BusinessException, Validation, AccessDenied, 그 외 Exception 처리

### Swagger 문서화
- SpringDoc 3.0.2 도입 (Spring Boot 4 호환 버전)
- `SwaggerConfig` 작성 + JWT Bearer 인증 통합
- SecurityConfig에 Swagger 경로 permitAll 추가

## ✅ PR 체크리스트
- [x] 컨벤션에 맞춰 작성했습니다.
- [x] 로컬에서 정상 동작 확인했습니다. (Swagger UI 정상 노출 + auth-controller 자동 인식 확인)
- [x] Reviewer를 지정했습니다.
