### PR TITLE
FEAT: 여권(Passport) 등록/수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -1,0 +1,55 @@
+// domain/passport/controller/PassportController.java
+package com.kauniv.lightrip.domain.passport.controller;
+
+import com.kauniv.lightrip.domain.passport.dto.request.PassportCreateRequest;
+import com.kauniv.lightrip.domain.passport.dto.request.PassportUpdateRequest;
+import com.kauniv.lightrip.domain.passport.dto.response.PassportResponse;
+import com.kauniv.lightrip.domain.passport.service.PassportService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Passport", description = "여권 등록/수정/삭제 API")
+@RestController
+@RequestMapping("/api/v1/passports")
+@RequiredArgsConstructor
+public class PassportController {
+
+    private final PassportService passportService;
+
+    @Operation(summary = "여권 등록", description = "방문 기록을 여권으로 등록합니다. 같은 사용자 + 같은 좌표 + 같은 날짜는 중복 등록 불가.")
+    @PostMapping
+    public ApiResponse<PassportResponse> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PassportCreateRequest request
+    ) {
+        return ApiResponse.success("여권이 등록되었습니다.", passportService.create(userId, request));
+    }
+
+    @Operation(summary = "여권 수정",
+            description = "여권 정보를 수정합니다. 위치/날짜는 수정 불가. 개인 여권은 본인만, 팀 여권은 팀원 누구나 수정 가능.")
+    @PatchMapping("/{passportId}")
+    public ApiResponse<PassportResponse> update(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId,
+            @Valid @RequestBody PassportUpdateRequest request
+    ) {
+        return ApiResponse.success("여권이 수정되었습니다.", passportService.update(userId, passportId, request));
+    }
+
+    @Operation(summary = "여권 삭제",
+            description = "여권을 삭제합니다. 작성자만 삭제 가능하며, 연관된 스크랩도 함께 삭제됩니다.")
+    @DeleteMapping("/{passportId}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId
+    ) {
+        passportService.delete(userId, passportId);
+        return ApiResponse.success("여권이 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
@@ -1,0 +1,76 @@
+// domain/passport/dto/request/PassportCreateRequest.java
+package com.kauniv.lightrip.domain.passport.dto.request;
+
+import com.kauniv.lightrip.global.enums.Category;
+import com.kauniv.lightrip.global.enums.District;
+import com.kauniv.lightrip.global.enums.Visibility;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Schema(description = "여권 등록 요청")
+public record PassportCreateRequest(
+
+        @Schema(description = "사진 URL", example = "https://cdn.lightrip.com/passport/abc.jpg")
+        @NotBlank(message = "사진 URL은 필수입니다.")
+        String imageUrl,
+
+        @Schema(description = "기록 내용", example = "오늘 다녀온 카페, 분위기 너무 좋았다.")
+        @NotBlank(message = "기록 내용은 필수입니다.")
+        String content,
+
+        @Schema(description = "위도", example = "37.5665")
+        @NotNull(message = "위도는 필수입니다.")
+        BigDecimal latitude,
+
+        @Schema(description = "경도", example = "126.9780")
+        @NotNull(message = "경도는 필수입니다.")
+        BigDecimal longitude,
+
+        @Schema(description = "전체 주소", example = "서울특별시 마포구 와우산로 123")
+        @NotBlank(message = "주소는 필수입니다.")
+        @Size(max = 50)
+        String address,
+
+        @Schema(description = "방문 날짜", example = "2026-04-15")
+        @NotNull(message = "방문 날짜는 필수입니다.")
+        @PastOrPresent(message = "방문 날짜는 미래일 수 없습니다.")
+        LocalDate visitedAt,
+
+        @Schema(description = "행정구역 (좌표 기반 자동 추출, 참고용)", example = "마포구")
+        @Size(max = 50)
+        String district,
+
+        @Schema(description = "사용자가 입력한 위치명", example = "안녕커피")
+        @Size(max = 50)
+        String spaceName,
+
+        @Schema(description = "카테고리", example = "CAFE")
+        @NotNull(message = "카테고리는 필수입니다.")
+        Category category,
+
+        @Schema(description = "권역 카테고리", example = "MAPO")
+        @NotNull(message = "권역 카테고리는 필수입니다.")
+        District districtCategory,
+
+        @Schema(description = "공개 범위 (기본 PUBLIC)", example = "PUBLIC",
+                defaultValue = "PUBLIC")
+        Visibility visibility,
+
+        @Schema(description = "음악 제목", example = "Headphones On")
+        @Size(max = 100)
+        String musicTitle,
+
+        @Schema(description = "음악 아티스트", example = "Addison Rae")
+        @Size(max = 100)
+        String musicArtist,
+
+        @Schema(description = "팀 ID (개인 여권이면 null)", example = "null")
+        Long teamId
+) {
+    public Visibility visibilityOrDefault() {
+        return visibility == null ? Visibility.PUBLIC : visibility;
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportUpdateRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportUpdateRequest.java
@@ -1,0 +1,38 @@
+// domain/passport/dto/request/PassportUpdateRequest.java
+package com.kauniv.lightrip.domain.passport.dto.request;
+
+import com.kauniv.lightrip.global.enums.Category;
+import com.kauniv.lightrip.global.enums.District;
+import com.kauniv.lightrip.global.enums.Visibility;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "여권 수정 요청 (위치/날짜는 수정 불가)")
+public record PassportUpdateRequest(
+
+        @Schema(description = "사진 URL")
+        @NotBlank String imageUrl,
+
+        @Schema(description = "기록 내용")
+        @NotBlank String content,
+
+        @Schema(description = "위치명")
+        @Size(max = 50) String spaceName,
+
+        @Schema(description = "카테고리")
+        @NotNull Category category,
+
+        @Schema(description = "권역 카테고리")
+        @NotNull District districtCategory,
+
+        @Schema(description = "공개 범위")
+        @NotNull Visibility visibility,
+
+        @Schema(description = "음악 제목")
+        @Size(max = 100) String musicTitle,
+
+        @Schema(description = "음악 아티스트")
+        @Size(max = 100) String musicArtist
+) {}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
@@ -1,0 +1,57 @@
+// domain/passport/dto/response/PassportResponse.java
+package com.kauniv.lightrip.domain.passport.dto.response;
+
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.global.enums.Category;
+import com.kauniv.lightrip.global.enums.District;
+import com.kauniv.lightrip.global.enums.Visibility;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Schema(description = "여권 응답")
+public record PassportResponse(
+        Long passportId,
+        Long userId,
+        Long teamId,
+        String imageUrl,
+        String content,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        String address,
+        LocalDate visitedAt,
+        String district,
+        String spaceName,
+        Category category,
+        District districtCategory,
+        Visibility visibility,
+        String musicTitle,
+        String musicArtist,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PassportResponse from(Passport p) {
+        return new PassportResponse(
+                p.getId(),
+                p.getUser().getId(),
+                p.getTeam() == null ? null : p.getTeam().getId(),
+                p.getImageUrl(),
+                p.getContent(),
+                p.getLatitude(),
+                p.getLongitude(),
+                p.getAddress(),
+                p.getVisitedAt(),
+                p.getDistrict(),
+                p.getSpaceName(),
+                p.getCategory(),
+                p.getDistrictCategory(),
+                p.getVisibility(),
+                p.getMusicTitle(),
+                p.getMusicArtist(),
+                p.getCreatedAt(),
+                p.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
@@ -4,6 +4,7 @@ import com.kauniv.lightrip.domain.team.entity.Team;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.global.enums.Category;
 import com.kauniv.lightrip.global.enums.District;
+import com.kauniv.lightrip.global.enums.Visibility;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -78,6 +79,10 @@ public class Passport {
     @Column(name = "district_category", nullable = false)
     private District districtCategory;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "visibility", nullable = false, length = 20)
+    private Visibility visibility;
+
     @Column(name = "music_title", length = 100)
     private String musicTitle;
 
@@ -92,15 +97,36 @@ public class Passport {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public void update(String imageUrl, String content, String spaceName,
-                       Category category, District districtCategory,
-                       String musicTitle, String musicArtist) {
+
+    public void update(String imageUrl,
+                       String content,
+                       String spaceName,
+                       Category category,
+                       District districtCategory,
+                       Visibility visibility,
+                       String musicTitle,
+                       String musicArtist) {
         this.imageUrl = imageUrl;
         this.content = content;
         this.spaceName = spaceName;
         this.category = category;
         this.districtCategory = districtCategory;
+        this.visibility = visibility;
         this.musicTitle = musicTitle;
         this.musicArtist = musicArtist;
+    }
+
+    /**
+     * 해당 사용자가 이 여권의 작성자인지 확인
+     */
+    public boolean isOwnedBy(Long userId) {
+        return this.user.getId().equals(userId);
+    }
+
+    /**
+     * 팀 모드 여권 여부
+     */
+    public boolean isTeamPassport() {
+        return this.team != null;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -1,7 +1,16 @@
+// domain/passport/repository/PassportRepository.java
 package com.kauniv.lightrip.domain.passport.repository;
 
 import com.kauniv.lightrip.domain.passport.entity.Passport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
 public interface PassportRepository extends JpaRepository<Passport, Long> {
+
+    // 중복 등록 방지 (uk_passport_user_location_date)
+    boolean existsByUser_IdAndLatitudeAndLongitudeAndVisitedAt(
+            Long userId, BigDecimal latitude, BigDecimal longitude, LocalDate visitedAt
+    );
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -1,0 +1,127 @@
+// domain/passport/service/PassportService.java
+package com.kauniv.lightrip.domain.passport.service;
+
+import com.kauniv.lightrip.domain.passport.dto.request.PassportCreateRequest;
+import com.kauniv.lightrip.domain.passport.dto.request.PassportUpdateRequest;
+import com.kauniv.lightrip.domain.passport.dto.response.PassportResponse;
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
+import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
+import com.kauniv.lightrip.domain.team.entity.Team;
+import com.kauniv.lightrip.domain.team.repository.TeamMemberRepository;
+import com.kauniv.lightrip.domain.team.repository.TeamRepository;
+import com.kauniv.lightrip.domain.user.entity.User;
+import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PassportService {
+
+    private final PassportRepository passportRepository;
+    private final ScrapRepository scrapRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    // ========== 등록 ==========
+    @Transactional
+    public PassportResponse create(Long userId, PassportCreateRequest req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 중복 체크 (같은 사용자 + 같은 좌표 + 같은 날짜)
+        if (passportRepository.existsByUser_IdAndLatitudeAndLongitudeAndVisitedAt(
+                userId, req.latitude(), req.longitude(), req.visitedAt())) {
+            throw new BusinessException(ErrorCode.PASSPORT_DUPLICATE);
+        }
+
+        // 팀 모드 검증: teamId가 있으면 해당 팀의 멤버여야 함
+        Team team = null;
+        if (req.teamId() != null) {
+            team = teamRepository.findById(req.teamId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
+
+            if (!teamMemberRepository.existsByTeam_IdAndUser_Id(team.getId(), userId)) {
+                throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
+            }
+        }
+
+        Passport passport = Passport.builder()
+                .user(user)
+                .team(team)
+                .imageUrl(req.imageUrl())
+                .content(req.content())
+                .latitude(req.latitude())
+                .longitude(req.longitude())
+                .address(req.address())
+                .visitedAt(req.visitedAt())
+                .district(req.district())
+                .spaceName(req.spaceName())
+                .category(req.category())
+                .districtCategory(req.districtCategory())
+                .visibility(req.visibilityOrDefault())
+                .musicTitle(req.musicTitle())
+                .musicArtist(req.musicArtist())
+                .build();
+
+        return PassportResponse.from(passportRepository.save(passport));
+    }
+
+    // ========== 수정 ==========
+    @Transactional
+    public PassportResponse update(Long userId, Long passportId, PassportUpdateRequest req) {
+        Passport passport = passportRepository.findById(passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
+
+        // 권한: 개인 여권 → 본인만 / 팀 여권 → 팀원 누구나
+        validateUpdatePermission(passport, userId);
+
+        passport.update(
+                req.imageUrl(), req.content(), req.spaceName(),
+                req.category(), req.districtCategory(), req.visibility(),
+                req.musicTitle(), req.musicArtist()
+        );
+
+        return PassportResponse.from(passport);
+    }
+
+    // ========== 삭제 ==========
+    @Transactional
+    public void delete(Long userId, Long passportId) {
+        Passport passport = passportRepository.findById(passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
+
+        // 권한: 개인/팀 여권 모두 → 작성자(본인)만 삭제 가능
+        if (!passport.isOwnedBy(userId)) {
+            throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
+        }
+
+        // 연관 스크랩 먼저 삭제 후 여권 삭제
+        scrapRepository.deleteAllByPassportId(passportId);
+        passportRepository.delete(passport);
+    }
+
+    // ========== 권한 검증 헬퍼 ==========
+    private void validateUpdatePermission(Passport passport, Long userId) {
+        if (passport.isTeamPassport()) {
+            // 팀 여권: 팀원이면 누구나 수정 가능
+            boolean isMember = teamMemberRepository.existsByTeam_IdAndUser_Id(
+                    passport.getTeam().getId(), userId
+            );
+            if (!isMember) {
+                throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
+            }
+        } else {
+            // 개인 여권: 본인만
+            if (!passport.isOwnedBy(userId)) {
+                throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
@@ -1,7 +1,15 @@
+// domain/scrap/repository/ScrapRepository.java
 package com.kauniv.lightrip.domain.scrap.repository;
 
 import com.kauniv.lightrip.domain.scrap.entity.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
+    // 여권 삭제 시 연관 스크랩 일괄 삭제 (성능 위해 bulk delete)
+    @Modifying
+    @Query("DELETE FROM Scrap s WHERE s.passport.id = :passportId")
+    void deleteAllByPassportId(Long passportId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
@@ -1,0 +1,9 @@
+package com.kauniv.lightrip.domain.team.repository;
+
+import com.kauniv.lightrip.domain.team.entity.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    boolean existsByTeam_IdAndUser_Id(Long teamId, Long userId);
+}

--- a/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package com.kauniv.lightrip.domain.team.repository;
+
+import com.kauniv.lightrip.domain.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/com/kauniv/lightrip/global/enums/Visibility.java
+++ b/src/main/java/com/kauniv/lightrip/global/enums/Visibility.java
@@ -1,0 +1,15 @@
+package com.kauniv.lightrip.global.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Visibility {
+
+    PUBLIC("공개"),
+    PRIVATE("비공개"),
+    FRIENDS_ONLY("친구만 공개");
+
+    private final String displayName;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #N

## 📝 작업 내용

###  Passport 엔티티에 visibility 컬럼 추가 및 엔티티 추가
- `Visibility` enum 신규 생성 (`PUBLIC` / `PRIVATE` / `FRIENDS_ONLY`)
- `Passport` 엔티티에 `visibility` 컬럼 추가 (`@Enumerated(STRING)`, NOT NULL)
- `Passport.update()` 시그니처에 `visibility` 파라미터 추가

### 🛂 여권 CRUD (C/U/D) API 구현
| Method | URL | 설명 |
|---|---|---|
| `POST` | `/api/v1/passports` | 여권 등록 |
| `PATCH` | `/api/v1/passports/{passportId}` | 여권 수정 |
| `DELETE` | `/api/v1/passports/{passportId}` | 여권 삭제 |

### 🏗 도메인 구조
- **DTO**: `PassportCreateRequest`, `PassportUpdateRequest`, `PassportResponse` (record + Bean Validation)
- **Controller**: `PassportController` (Swagger `@Tag`, `@Operation`, `@Schema` 포함)
- **Service**: `PassportService` (등록/수정/삭제 + 권한 검증 헬퍼)
- **Repository**: 
  - `PassportRepository` — 중복 체크용 `existsByUser_IdAndLatitudeAndLongitudeAndVisitedAt` 추가
  - `ScrapRepository` — 여권 삭제 시 연관 스크랩 일괄 제거용 `deleteAllByPassportId` 추가
  - `TeamRepository`, `TeamMemberRepository` 신규 생성

### 🧠 도메인 메서드 (Passport)
- `update(...)` — visibility 포함 시그니처로 확장
- `isOwnedBy(Long userId)` — 작성자 검증
- `isTeamPassport()` — 팀 여권 여부 확인

## 🔐 권한 정책
| 작업 | 개인 여권 | 팀 모드 여권 |
|---|---|---|
| 등록 | 본인 | 팀원 (소속 검증) |
| 수정 | 본인만 | 팀원 누구나 |
| 삭제 | 본인만 | **작성자만** |

권한 위반 시 → `BusinessException(PASSPORT_FORBIDDEN)`

## 📌 수정/삭제 정책
- **수정 불가 필드**: `latitude`, `longitude`, `address`, `visitedAt`, `teamId`
- **삭제 시**: 연관 스크랩 기록도 함께 삭제 (bulk delete)

## 🚨 예외 처리
기존 `ErrorCode` 활용:
- `PASSPORT_NOT_FOUND` (P001) — 존재하지 않는 여권
- `PASSPORT_FORBIDDEN` (P002) — 권한 없음
- `PASSPORT_DUPLICATE` (P003) — 같은 위치/날짜 중복 등록
- `USER_NOT_FOUND` (U001), `TEAM_NOT_FOUND` (T001) — 연관 엔티티 미존재


## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.
