### PR TITLE
FEAT: 여권 상세 조회, 스크랩 API + 좋아요/스크랩 카운트 및 이미지 다건 지원을 위한 데이터베이스 수정 

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
@@ -1,0 +1,16 @@
+package com.kauniv.lightrip.domain.friend.repository;
+
+import com.kauniv.lightrip.domain.friend.entity.Friend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    @Query("""
+            SELECT COUNT(f) > 0 FROM Friend f
+            WHERE f.status = com.kauniv.lightrip.domain.friend.entity.Friend$Status.ACCEPTED
+              AND ((f.requester.id = :userA AND f.receiver.id = :userB)
+                OR (f.requester.id = :userB AND f.receiver.id = :userA))
+            """)
+    boolean isFriend(Long userA, Long userB);
+}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
@@ -8,7 +8,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     @Query("""
             SELECT COUNT(f) > 0 FROM Friend f
-            WHERE f.status = com.kauniv.lightrip.domain.friend.entity.Friend$Status.ACCEPTED
+            WHERE f.status = 'ACCEPTED'
               AND ((f.requester.id = :userA AND f.receiver.id = :userB)
                 OR (f.requester.id = :userB AND f.receiver.id = :userA))
             """)

--- a/src/main/java/com/kauniv/lightrip/domain/like/entity/Like.java
+++ b/src/main/java/com/kauniv/lightrip/domain/like/entity/Like.java
@@ -1,0 +1,47 @@
+package com.kauniv.lightrip.domain.like.entity;
+
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "likes",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_like_user_passport",
+                        columnNames = {"user_id", "passport_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "passport_id", nullable = false)
+    private Passport passport;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -1,4 +1,3 @@
-// domain/passport/controller/PassportController.java
 package com.kauniv.lightrip.domain.passport.controller;
 
 import com.kauniv.lightrip.domain.passport.dto.request.PassportCreateRequest;
@@ -14,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Passport", description = "여권 등록/수정/삭제 API")
+@Tag(name = "Passport", description = "여권 API")
 @RestController
 @RequestMapping("/api/v1/passports")
 @RequiredArgsConstructor
@@ -22,7 +21,8 @@ public class PassportController {
 
     private final PassportService passportService;
 
-    @Operation(summary = "여권 등록", description = "방문 기록을 여권으로 등록합니다. 같은 사용자 + 같은 좌표 + 같은 날짜는 중복 등록 불가.")
+    @Operation(summary = "여권 등록",
+            description = "방문 기록을 여권으로 등록합니다. 이미지 1~5장 필수.")
     @PostMapping
     public ApiResponse<PassportResponse> create(
             @AuthenticationPrincipal Long userId,
@@ -32,7 +32,7 @@ public class PassportController {
     }
 
     @Operation(summary = "여권 수정",
-            description = "여권 정보를 수정합니다. 위치/날짜는 수정 불가. 개인 여권은 본인만, 팀 여권은 팀원 누구나 수정 가능.")
+            description = "여권 정보를 수정합니다. 위치/날짜 수정 불가. 개인=본인만, 팀=팀원 누구나.")
     @PatchMapping("/{passportId}")
     public ApiResponse<PassportResponse> update(
             @AuthenticationPrincipal Long userId,
@@ -43,7 +43,7 @@ public class PassportController {
     }
 
     @Operation(summary = "여권 삭제",
-            description = "여권을 삭제합니다. 작성자만 삭제 가능하며, 연관된 스크랩도 함께 삭제됩니다.")
+            description = "여권을 삭제합니다. 작성자만 삭제 가능하며, 연관 스크랩도 함께 삭제됩니다.")
     @DeleteMapping("/{passportId}")
     public ApiResponse<Void> delete(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -52,4 +52,14 @@ public class PassportController {
         passportService.delete(userId, passportId);
         return ApiResponse.success("여권이 삭제되었습니다.", null);
     }
+
+    @Operation(summary = "여권 상세 조회",
+            description = "여권 상세 정보를 조회합니다. 공개 범위(visibility)에 따라 접근이 제한됩니다.")
+    @GetMapping("/{passportId}")
+    public ApiResponse<PassportResponse> getPassport(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId
+    ) {
+        return ApiResponse.success(passportService.getPassport(userId, passportId));
+    }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
@@ -1,4 +1,3 @@
-// domain/passport/dto/request/PassportCreateRequest.java
 package com.kauniv.lightrip.domain.passport.dto.request;
 
 import com.kauniv.lightrip.global.enums.Category;
@@ -9,13 +8,16 @@ import jakarta.validation.constraints.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 
 @Schema(description = "여권 등록 요청")
 public record PassportCreateRequest(
 
-        @Schema(description = "사진 URL", example = "https://cdn.lightrip.com/passport/abc.jpg")
-        @NotBlank(message = "사진 URL은 필수입니다.")
-        String imageUrl,
+        @Schema(description = "사진 URL 목록 (최소 1장, 최대 5장)",
+                example = "[\"https://cdn.lightrip.com/img/1.jpg\", \"https://cdn.lightrip.com/img/2.jpg\"]")
+        @NotNull(message = "이미지는 필수입니다.")
+        @Size(min = 1, max = 5, message = "이미지는 1장 이상 5장 이하여야 합니다.")
+        List<@NotBlank(message = "이미지 URL은 비어있을 수 없습니다.") String> imageUrls,
 
         @Schema(description = "기록 내용", example = "오늘 다녀온 카페, 분위기 너무 좋았다.")
         @NotBlank(message = "기록 내용은 필수입니다.")
@@ -39,11 +41,11 @@ public record PassportCreateRequest(
         @PastOrPresent(message = "방문 날짜는 미래일 수 없습니다.")
         LocalDate visitedAt,
 
-        @Schema(description = "행정구역 (좌표 기반 자동 추출, 참고용)", example = "마포구")
+        @Schema(description = "행정구역 (참고용)", example = "마포구")
         @Size(max = 50)
         String district,
 
-        @Schema(description = "사용자가 입력한 위치명", example = "안녕커피")
+        @Schema(description = "위치명", example = "안녕커피")
         @Size(max = 50)
         String spaceName,
 
@@ -55,8 +57,7 @@ public record PassportCreateRequest(
         @NotNull(message = "권역 카테고리는 필수입니다.")
         District districtCategory,
 
-        @Schema(description = "공개 범위 (기본 PUBLIC)", example = "PUBLIC",
-                defaultValue = "PUBLIC")
+        @Schema(description = "공개 범위 (기본 PUBLIC)", example = "PUBLIC")
         Visibility visibility,
 
         @Schema(description = "음악 제목", example = "Headphones On")
@@ -67,7 +68,7 @@ public record PassportCreateRequest(
         @Size(max = 100)
         String musicArtist,
 
-        @Schema(description = "팀 ID (개인 여권이면 null)", example = "null")
+        @Schema(description = "팀 ID (개인 여권이면 null)")
         Long teamId
 ) {
     public Visibility visibilityOrDefault() {

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportUpdateRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportUpdateRequest.java
@@ -1,38 +1,46 @@
-// domain/passport/dto/request/PassportUpdateRequest.java
 package com.kauniv.lightrip.domain.passport.dto.request;
 
 import com.kauniv.lightrip.global.enums.Category;
 import com.kauniv.lightrip.global.enums.District;
 import com.kauniv.lightrip.global.enums.Visibility;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
-@Schema(description = "여권 수정 요청 (위치/날짜는 수정 불가)")
+import java.util.List;
+
+@Schema(description = "여권 수정 요청 (위치/날짜 수정 불가)")
 public record PassportUpdateRequest(
 
-        @Schema(description = "사진 URL")
-        @NotBlank String imageUrl,
+        @Schema(description = "사진 URL 목록 (최소 1장, 최대 5장)")
+        @NotNull(message = "이미지는 필수입니다.")
+        @Size(min = 1, max = 5, message = "이미지는 1장 이상 5장 이하여야 합니다.")
+        List<@NotBlank(message = "이미지 URL은 비어있을 수 없습니다.") String> imageUrls,
 
         @Schema(description = "기록 내용")
-        @NotBlank String content,
+        @NotBlank(message = "기록 내용은 필수입니다.")
+        String content,
 
         @Schema(description = "위치명")
-        @Size(max = 50) String spaceName,
+        @Size(max = 50)
+        String spaceName,
 
         @Schema(description = "카테고리")
-        @NotNull Category category,
+        @NotNull(message = "카테고리는 필수입니다.")
+        Category category,
 
         @Schema(description = "권역 카테고리")
-        @NotNull District districtCategory,
+        @NotNull(message = "권역 카테고리는 필수입니다.")
+        District districtCategory,
 
         @Schema(description = "공개 범위")
-        @NotNull Visibility visibility,
+        @NotNull(message = "공개 범위는 필수입니다.")
+        Visibility visibility,
 
         @Schema(description = "음악 제목")
-        @Size(max = 100) String musicTitle,
+        @Size(max = 100)
+        String musicTitle,
 
         @Schema(description = "음악 아티스트")
-        @Size(max = 100) String musicArtist
+        @Size(max = 100)
+        String musicArtist
 ) {}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
@@ -30,6 +30,8 @@ public record PassportResponse(
         Visibility visibility,
         String musicTitle,
         String musicArtist,
+        Long likeCount,
+        Long scrapCount,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -55,6 +57,8 @@ public record PassportResponse(
                 p.getVisibility(),
                 p.getMusicTitle(),
                 p.getMusicArtist(),
+                p.getLikeCount(),       // 🆕
+                p.getScrapCount(),      // 🆕
                 p.getCreatedAt(),
                 p.getUpdatedAt()
         );

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
@@ -1,7 +1,7 @@
-// domain/passport/dto/response/PassportResponse.java
 package com.kauniv.lightrip.domain.passport.dto.response;
 
 import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.domain.passport.entity.PassportImage;
 import com.kauniv.lightrip.global.enums.Category;
 import com.kauniv.lightrip.global.enums.District;
 import com.kauniv.lightrip.global.enums.Visibility;
@@ -10,13 +10,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(description = "여권 응답")
 public record PassportResponse(
         Long passportId,
         Long userId,
         Long teamId,
-        String imageUrl,
+        List<String> imageUrls,
         String content,
         BigDecimal latitude,
         BigDecimal longitude,
@@ -33,11 +34,15 @@ public record PassportResponse(
         LocalDateTime updatedAt
 ) {
     public static PassportResponse from(Passport p) {
+        List<String> urls = p.getImages().stream()
+                .map(PassportImage::getImageUrl)
+                .toList();
+
         return new PassportResponse(
                 p.getId(),
                 p.getUser().getId(),
                 p.getTeam() == null ? null : p.getTeam().getId(),
-                p.getImageUrl(),
+                urls,
                 p.getContent(),
                 p.getLatitude(),
                 p.getLongitude(),

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
@@ -17,6 +17,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(
@@ -47,8 +49,10 @@ public class Passport {
     @JoinColumn(name = "team_id")
     private Team team;
 
-    @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
-    private String imageUrl;
+    @OneToMany(mappedBy = "passport", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("imageOrder ASC")
+    @Builder.Default
+    private List<PassportImage> images = new ArrayList<>();
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
@@ -98,15 +102,13 @@ public class Passport {
     private LocalDateTime updatedAt;
 
 
-    public void update(String imageUrl,
-                       String content,
+    public void update(String content,
                        String spaceName,
                        Category category,
                        District districtCategory,
                        Visibility visibility,
                        String musicTitle,
                        String musicArtist) {
-        this.imageUrl = imageUrl;
         this.content = content;
         this.spaceName = spaceName;
         this.category = category;
@@ -114,6 +116,19 @@ public class Passport {
         this.visibility = visibility;
         this.musicTitle = musicTitle;
         this.musicArtist = musicArtist;
+    }
+
+    public void replaceImages(List<String> imageUrls) {
+        this.images.clear();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            this.images.add(
+                    PassportImage.builder()
+                            .passport(this)
+                            .imageUrl(imageUrls.get(i))
+                            .imageOrder(i + 1)
+                            .build()
+            );
+        }
     }
 
     /**

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
@@ -93,6 +93,14 @@ public class Passport {
     @Column(name = "music_artist", length = 100)
     private String musicArtist;
 
+    @Column(name = "like_count", nullable = false)
+    @Builder.Default
+    private Long likeCount = 0L;
+
+    @Column(name = "scrap_count", nullable = false)
+    @Builder.Default
+    private Long scrapCount = 0L;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -143,5 +151,25 @@ public class Passport {
      */
     public boolean isTeamPassport() {
         return this.team != null;
+    }
+
+    // ============================================================
+    // 좋아요 / 스크랩 카운트
+    // ============================================================
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) this.likeCount--;
+    }
+
+    public void increaseScrapCount() {
+        this.scrapCount++;
+    }
+
+    public void decreaseScrapCount() {
+        if (this.scrapCount > 0) this.scrapCount--;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/PassportImage.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/PassportImage.java
@@ -1,0 +1,39 @@
+package com.kauniv.lightrip.domain.passport.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "passport_image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PassportImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "passport_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "passport_id", nullable = false)
+    private Passport passport;
+
+    @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "image_order", nullable = false)
+    private Integer imageOrder;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportImageRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportImageRepository.java
@@ -1,0 +1,13 @@
+package com.kauniv.lightrip.domain.passport.repository;
+
+import com.kauniv.lightrip.domain.passport.entity.PassportImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PassportImageRepository extends JpaRepository<PassportImage, Long> {
+
+    @Modifying
+    @Query("DELETE FROM PassportImage pi WHERE pi.passport.id = :passportId")
+    void deleteAllByPassportId(Long passportId);
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -16,6 +16,7 @@ import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.kauniv.lightrip.domain.friend.repository.FriendRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ public class PassportService {
     private final UserRepository userRepository;
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final FriendRepository friendRepository;
 
     // ========== 등록 ==========
     @Transactional
@@ -117,6 +119,46 @@ public class PassportService {
             if (!passport.isOwnedBy(userId)) {
                 throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
             }
+        }
+    }
+
+    // ========== 상세 조회 ==========
+    public PassportResponse getPassport(Long userId, Long passportId) {
+        Passport passport = passportRepository.findById(passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
+
+        validateReadPermission(passport, userId);
+
+        return PassportResponse.from(passport);
+    }
+
+    // ========== 조회 권한 검증 (Visibility) ==========
+    private void validateReadPermission(Passport passport, Long userId) {
+        if (passport.isOwnedBy(userId)) {
+            return;
+        }
+
+        if (passport.isTeamPassport()) {
+            boolean isMember = teamMemberRepository.existsByTeam_IdAndUser_Id(
+                    passport.getTeam().getId(), userId
+            );
+            if (isMember) {
+                return;
+            }
+        }
+
+        switch (passport.getVisibility()) {
+            case PUBLIC -> {
+                return;
+            }
+            case FRIENDS_ONLY -> {
+                Long ownerId = passport.getUser().getId();
+                if (friendRepository.isFriend(userId, ownerId)) {
+                    return;
+                }
+                throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
+            }
+            case PRIVATE -> throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -161,4 +161,11 @@ public class PassportService {
             case PRIVATE -> throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
     }
+    public Passport getPassportWithReadCheck(Long userId, Long passportId) {
+        Passport passport = passportRepository.findById(passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
+        validateReadPermission(passport, userId);
+        return passport;
+    }
 }
+

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -1,4 +1,3 @@
-// domain/passport/service/PassportService.java
 package com.kauniv.lightrip.domain.passport.service;
 
 import com.kauniv.lightrip.domain.passport.dto.request.PassportCreateRequest;
@@ -35,18 +34,15 @@ public class PassportService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // 중복 체크 (같은 사용자 + 같은 좌표 + 같은 날짜)
         if (passportRepository.existsByUser_IdAndLatitudeAndLongitudeAndVisitedAt(
                 userId, req.latitude(), req.longitude(), req.visitedAt())) {
             throw new BusinessException(ErrorCode.PASSPORT_DUPLICATE);
         }
 
-        // 팀 모드 검증: teamId가 있으면 해당 팀의 멤버여야 함
         Team team = null;
         if (req.teamId() != null) {
             team = teamRepository.findById(req.teamId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
-
             if (!teamMemberRepository.existsByTeam_IdAndUser_Id(team.getId(), userId)) {
                 throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
             }
@@ -55,7 +51,6 @@ public class PassportService {
         Passport passport = Passport.builder()
                 .user(user)
                 .team(team)
-                .imageUrl(req.imageUrl())
                 .content(req.content())
                 .latitude(req.latitude())
                 .longitude(req.longitude())
@@ -70,7 +65,10 @@ public class PassportService {
                 .musicArtist(req.musicArtist())
                 .build();
 
-        return PassportResponse.from(passportRepository.save(passport));
+        passportRepository.save(passport);
+        passport.replaceImages(req.imageUrls());
+
+        return PassportResponse.from(passport);
     }
 
     // ========== 수정 ==========
@@ -79,14 +77,15 @@ public class PassportService {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
 
-        // 권한: 개인 여권 → 본인만 / 팀 여권 → 팀원 누구나
         validateUpdatePermission(passport, userId);
 
         passport.update(
-                req.imageUrl(), req.content(), req.spaceName(),
+                req.content(), req.spaceName(),
                 req.category(), req.districtCategory(), req.visibility(),
                 req.musicTitle(), req.musicArtist()
         );
+
+        passport.replaceImages(req.imageUrls());
 
         return PassportResponse.from(passport);
     }
@@ -97,20 +96,17 @@ public class PassportService {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
 
-        // 권한: 개인/팀 여권 모두 → 작성자(본인)만 삭제 가능
         if (!passport.isOwnedBy(userId)) {
             throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
 
-        // 연관 스크랩 먼저 삭제 후 여권 삭제
         scrapRepository.deleteAllByPassportId(passportId);
         passportRepository.delete(passport);
     }
 
-    // ========== 권한 검증 헬퍼 ==========
+    // ========== 수정 권한 검증 ==========
     private void validateUpdatePermission(Passport passport, Long userId) {
         if (passport.isTeamPassport()) {
-            // 팀 여권: 팀원이면 누구나 수정 가능
             boolean isMember = teamMemberRepository.existsByTeam_IdAndUser_Id(
                     passport.getTeam().getId(), userId
             );
@@ -118,7 +114,6 @@ public class PassportService {
                 throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
             }
         } else {
-            // 개인 여권: 본인만
             if (!passport.isOwnedBy(userId)) {
                 throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
             }

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/controller/ScrapController.java
@@ -1,8 +1,10 @@
 package com.kauniv.lightrip.domain.scrap.controller;
 
+import com.kauniv.lightrip.domain.scrap.dto.response.ScrapListResponse;
 import com.kauniv.lightrip.domain.scrap.dto.response.ScrapResponse;
 import com.kauniv.lightrip.domain.scrap.service.ScrapService;
 import com.kauniv.lightrip.global.common.response.ApiResponse;
+import com.kauniv.lightrip.global.common.response.CursorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Scrap", description = "여권 스크랩 API")
 @RestController
-@RequestMapping("/api/v1/passports/{passportId}/scraps")
 @RequiredArgsConstructor
 public class ScrapController {
 
@@ -20,7 +21,7 @@ public class ScrapController {
 
     @Operation(summary = "스크랩 등록",
             description = "여권을 스크랩합니다. 본인 여권도 스크랩 가능. 중복 스크랩 불가.")
-    @PostMapping
+    @PostMapping("/api/v1/passports/{passportId}/scraps")
     public ApiResponse<ScrapResponse> create(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "여권 ID") @PathVariable Long passportId
@@ -30,12 +31,25 @@ public class ScrapController {
 
     @Operation(summary = "스크랩 취소",
             description = "여권 스크랩을 취소합니다.")
-    @DeleteMapping
+    @DeleteMapping("/api/v1/passports/{passportId}/scraps")
     public ApiResponse<Void> delete(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "여권 ID") @PathVariable Long passportId
     ) {
         scrapService.delete(userId, passportId);
         return ApiResponse.success("스크랩이 취소되었습니다.", null);
+    }
+
+    @Operation(summary = "내 스크랩 목록 조회",
+            description = "내가 스크랩한 여권 목록을 커서 기반으로 조회합니다.")
+    @GetMapping("/api/v1/passports/scraps/me")
+    public ApiResponse<CursorResponse<ScrapListResponse>> getMyScraps(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "커서 (마지막 스크랩 ID, 첫 요청 시 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "조회 개수 (기본 10)")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.success(scrapService.getMyScraps(userId, cursor, size));
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/controller/ScrapController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/controller/ScrapController.java
@@ -1,0 +1,41 @@
+package com.kauniv.lightrip.domain.scrap.controller;
+
+import com.kauniv.lightrip.domain.scrap.dto.response.ScrapResponse;
+import com.kauniv.lightrip.domain.scrap.service.ScrapService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Scrap", description = "여권 스크랩 API")
+@RestController
+@RequestMapping("/api/v1/passports/{passportId}/scraps")
+@RequiredArgsConstructor
+public class ScrapController {
+
+    private final ScrapService scrapService;
+
+    @Operation(summary = "스크랩 등록",
+            description = "여권을 스크랩합니다. 본인 여권도 스크랩 가능. 중복 스크랩 불가.")
+    @PostMapping
+    public ApiResponse<ScrapResponse> create(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId
+    ) {
+        return ApiResponse.success("스크랩이 등록되었습니다.", scrapService.create(userId, passportId));
+    }
+
+    @Operation(summary = "스크랩 취소",
+            description = "여권 스크랩을 취소합니다.")
+    @DeleteMapping
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId
+    ) {
+        scrapService.delete(userId, passportId);
+        return ApiResponse.success("스크랩이 취소되었습니다.", null);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/dto/response/ScrapListResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/dto/response/ScrapListResponse.java
@@ -1,0 +1,58 @@
+package com.kauniv.lightrip.domain.scrap.dto.response;
+
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.domain.scrap.entity.Scrap;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "스크랩 목록 항목")
+public record ScrapListResponse(
+
+        @Schema(description = "스크랩 ID (커서로 사용)")
+        Long scrapId,
+
+        @Schema(description = "스크랩 생성일시")
+        LocalDateTime scrapCreatedAt,
+
+        @Schema(description = "여권 ID")
+        Long passportId,
+
+        @Schema(description = "대표 이미지 URL (첫 번째 이미지)")
+        String thumbnailUrl,
+
+        @Schema(description = "기록 내용")
+        String content,
+
+        @Schema(description = "주소")
+        String address,
+
+        @Schema(description = "위치명")
+        String spaceName,
+
+        @Schema(description = "좋아요 수")
+        Long likeCount,
+
+        @Schema(description = "스크랩 수")
+        Long scrapCount
+) {
+    public static ScrapListResponse from(Scrap scrap) {
+        Passport p = scrap.getPassport();
+
+        String thumbnail = p.getImages().isEmpty()
+                ? null
+                : p.getImages().get(0).getImageUrl();
+
+        return new ScrapListResponse(
+                scrap.getId(),
+                scrap.getCreatedAt(),
+                p.getId(),
+                thumbnail,
+                p.getContent(),
+                p.getAddress(),
+                p.getSpaceName(),
+                p.getLikeCount(),
+                p.getScrapCount()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/dto/response/ScrapResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/dto/response/ScrapResponse.java
@@ -1,0 +1,21 @@
+package com.kauniv.lightrip.domain.scrap.dto.response;
+
+import com.kauniv.lightrip.domain.scrap.entity.Scrap;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "스크랩 응답")
+public record ScrapResponse(
+        Long scrapId,
+        Long passportId,
+        LocalDateTime createdAt
+) {
+    public static ScrapResponse from(Scrap scrap) {
+        return new ScrapResponse(
+                scrap.getId(),
+                scrap.getPassport().getId(),
+                scrap.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
@@ -6,10 +6,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     // 여권 삭제 시 연관 스크랩 일괄 삭제 (성능 위해 bulk delete)
     @Modifying
     @Query("DELETE FROM Scrap s WHERE s.passport.id = :passportId")
     void deleteAllByPassportId(Long passportId);
+
+    // 중복 스크랩 체크
+    boolean existsByUser_IdAndPassport_Id(Long userId, Long passportId);
+
+    // 스크랩 취소용 조회
+    Optional<Scrap> findByUser_IdAndPassport_Id(Long userId, Long passportId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
@@ -1,4 +1,3 @@
-// domain/scrap/repository/ScrapRepository.java
 package com.kauniv.lightrip.domain.scrap.repository;
 
 import com.kauniv.lightrip.domain.scrap.entity.Scrap;
@@ -6,11 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
-    // 여권 삭제 시 연관 스크랩 일괄 삭제 (성능 위해 bulk delete)
+    // 여권 삭제 시 연관 스크랩 일괄 삭제
     @Modifying
     @Query("DELETE FROM Scrap s WHERE s.passport.id = :passportId")
     void deleteAllByPassportId(Long passportId);
@@ -20,4 +20,26 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     // 스크랩 취소용 조회
     Optional<Scrap> findByUser_IdAndPassport_Id(Long userId, Long passportId);
+
+    // 커서 기반 목록 조회 (첫 요청)
+    @Query("""
+            SELECT s FROM Scrap s
+            JOIN FETCH s.passport p
+            LEFT JOIN FETCH p.images
+            WHERE s.user.id = :userId
+            ORDER BY s.id DESC
+            LIMIT :size
+            """)
+    List<Scrap> findByUserIdFirst(Long userId, int size);
+
+    // 커서 기반 목록 조회 (다음 페이지)
+    @Query("""
+            SELECT s FROM Scrap s
+            JOIN FETCH s.passport p
+            LEFT JOIN FETCH p.images
+            WHERE s.user.id = :userId AND s.id < :cursor
+            ORDER BY s.id DESC
+            LIMIT :size
+            """)
+    List<Scrap> findByUserIdAfterCursor(Long userId, Long cursor, int size);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/service/ScrapService.java
@@ -2,6 +2,7 @@ package com.kauniv.lightrip.domain.scrap.service;
 
 import com.kauniv.lightrip.domain.passport.entity.Passport;
 import com.kauniv.lightrip.domain.passport.service.PassportService;
+import com.kauniv.lightrip.domain.scrap.dto.response.ScrapListResponse;
 import com.kauniv.lightrip.domain.scrap.dto.response.ScrapResponse;
 import com.kauniv.lightrip.domain.scrap.entity.Scrap;
 import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
@@ -9,9 +10,12 @@ import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import com.kauniv.lightrip.global.common.response.CursorResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,10 +32,8 @@ public class ScrapService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // 여권 존재 + visibility 접근 권한 검증
         Passport passport = passportService.getPassportWithReadCheck(userId, passportId);
 
-        // 중복 스크랩 체크
         if (scrapRepository.existsByUser_IdAndPassport_Id(userId, passportId)) {
             throw new BusinessException(ErrorCode.SCRAP_DUPLICATE);
         }
@@ -40,6 +42,8 @@ public class ScrapService {
                 .user(user)
                 .passport(passport)
                 .build();
+
+        passport.increaseScrapCount();
 
         return ScrapResponse.from(scrapRepository.save(scrap));
     }
@@ -50,6 +54,29 @@ public class ScrapService {
         Scrap scrap = scrapRepository.findByUser_IdAndPassport_Id(userId, passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SCRAP_NOT_FOUND));
 
+        scrap.getPassport().decreaseScrapCount();
+
         scrapRepository.delete(scrap);
+    }
+
+    // ========== 내 스크랩 목록 조회 (커서 기반) ==========
+    public CursorResponse<ScrapListResponse> getMyScraps(Long userId, Long cursor, int size) {
+        List<Scrap> scraps = (cursor == null)
+                ? scrapRepository.findByUserIdFirst(userId, size + 1)
+                : scrapRepository.findByUserIdAfterCursor(userId, cursor, size + 1);
+
+        boolean hasNext = scraps.size() > size;
+
+        if (hasNext) {
+            scraps = scraps.subList(0, size);
+        }
+
+        List<ScrapListResponse> content = scraps.stream()
+                .map(ScrapListResponse::from)
+                .toList();
+
+        Long nextCursor = hasNext ? scraps.get(scraps.size() - 1).getId() : null;
+
+        return CursorResponse.of(content, hasNext, nextCursor);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/service/ScrapService.java
@@ -1,0 +1,55 @@
+package com.kauniv.lightrip.domain.scrap.service;
+
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.domain.passport.service.PassportService;
+import com.kauniv.lightrip.domain.scrap.dto.response.ScrapResponse;
+import com.kauniv.lightrip.domain.scrap.entity.Scrap;
+import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
+import com.kauniv.lightrip.domain.user.entity.User;
+import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScrapService {
+
+    private final ScrapRepository scrapRepository;
+    private final UserRepository userRepository;
+    private final PassportService passportService;
+
+    // ========== 스크랩 등록 ==========
+    @Transactional
+    public ScrapResponse create(Long userId, Long passportId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 여권 존재 + visibility 접근 권한 검증
+        Passport passport = passportService.getPassportWithReadCheck(userId, passportId);
+
+        // 중복 스크랩 체크
+        if (scrapRepository.existsByUser_IdAndPassport_Id(userId, passportId)) {
+            throw new BusinessException(ErrorCode.SCRAP_DUPLICATE);
+        }
+
+        Scrap scrap = Scrap.builder()
+                .user(user)
+                .passport(passport)
+                .build();
+
+        return ScrapResponse.from(scrapRepository.save(scrap));
+    }
+
+    // ========== 스크랩 취소 ==========
+    @Transactional
+    public void delete(Long userId, Long passportId) {
+        Scrap scrap = scrapRepository.findByUser_IdAndPassport_Id(userId, passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SCRAP_NOT_FOUND));
+
+        scrapRepository.delete(scrap);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -39,7 +39,11 @@ public enum ErrorCode {
     TEAM_INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "T003", "유효하지 않은 초대 코드입니다."),
 
     // ===== Map =====
-    REVERSE_GEOCODE_FAILED(HttpStatus.BAD_GATEWAY, "M001", "역지오코딩에 실패했습니다.");
+    REVERSE_GEOCODE_FAILED(HttpStatus.BAD_GATEWAY, "M001", "역지오코딩에 실패했습니다."),
+
+    // ===== Like =====
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "좋아요 기록이 존재하지 않습니다."),
+    LIKE_DUPLICATE(HttpStatus.CONFLICT, "L002", "이미 좋아요한 여권입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/kauniv/lightrip/global/common/response/CursorResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/response/CursorResponse.java
@@ -1,0 +1,22 @@
+package com.kauniv.lightrip.global.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "커서 기반 페이징 응답")
+public record CursorResponse<T>(
+
+        @Schema(description = "데이터 목록")
+        List<T> content,
+
+        @Schema(description = "다음 페이지 존재 여부")
+        boolean hasNext,
+
+        @Schema(description = "다음 요청에 사용할 커서 (마지막 항목의 ID)")
+        Long nextCursor
+) {
+    public static <T> CursorResponse<T> of(List<T> content, boolean hasNext, Long nextCursor) {
+        return new CursorResponse<>(content, hasNext, nextCursor);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #15

## 📝 작업 내용

###  Passport 이미지 다건 지원
- `Passport.imageUrl` 단일 필드 삭제 → `PassportImage` 별도 테이블로 분리
- 1:N 관계 (`@OneToMany`, `cascade = ALL`, `orphanRemoval = true`)
- 이미지 최소 1장, 최대 5장 제한 (Bean Validation `@Size`)
- `Passport.replaceImages()` 도메인 메서드로 이미지 전체 교체

###  여권 상세 조회 API
| Method | URL | 설명 |
|---|---|---|
| `GET` | `/api/v1/passports/{passportId}` | 여권 상세 조회 |

**Visibility 기반 접근 제어:**
| Visibility | 본인 | 팀원 (팀 여권) | 친구 | 그 외 로그인 유저 |
|---|---|---|---|---|
| `PUBLIC` | ✅ | ✅ | ✅ | ✅ |
| `FRIENDS_ONLY` | ✅ | ✅ | ✅ | ❌ |
| `PRIVATE` | ✅ | ✅ | ❌ | ❌ |

### 여권 스크랩 API
| Method | URL | 설명 |
|---|---|---|
| `POST` | `/api/v1/passports/{passportId}/scraps` | 스크랩 등록 |
| `DELETE` | `/api/v1/passports/{passportId}/scraps` | 스크랩 취소 |
| `GET` | `/api/v1/passports/scraps/me` | 내 스크랩 목록 (커서 기반) |

- 본인 여권 스크랩 **허용**
- 중복 스크랩 시 → `SCRAP_DUPLICATE` (S002)
- 목록 조회는 **커서 기반 무한스크롤** (scrapId 내림차순)

### 좋아요 / 스크랩 카운트 기반 구축
- `Like` 엔티티 신규 생성 (likes 테이블)
- `Passport` 엔티티에 `likeCount`, `scrapCount` 비정규화 컬럼 추가
- 스크랩 등록/취소 시 `scrapCount` 자동 증감
- `PassportResponse`에 `likeCount`, `scrapCount` 포함
- **좋아요 API는 다음 PR에서 구현 예정**

### 🤝 FriendRepository 신규 생성
- `isFriend(userA, userB)` — 양방향 친구 관계 확인 (ACCEPTED 상태)
- `FRIENDS_ONLY` Visibility 접근 제어에 사용

## 🏗 신규 / 수정 파일

### 🆕 신규
| 파일 | 설명 |
|---|---|
| `PassportImage.java` | 여권 이미지 엔티티 |
| `PassportImageRepository.java` | 이미지 Repository |
| `Like.java` | 좋아요 엔티티 |
| `FriendRepository.java` | 친구 관계 확인 |
| `ScrapResponse.java` | 스크랩 등록 응답 DTO |
| `ScrapListResponse.java` | 스크랩 목록 항목 DTO |
| `CursorResponse.java` | 공통 커서 페이징 응답 |
| `ScrapService.java` | 스크랩 비즈니스 로직 |
| `ScrapController.java` | 스크랩 API 컨트롤러 |

### 🔄 수정
| 파일 | 변경 내용 |
|---|---|
| `Passport.java` | `imageUrl` 삭제 → `images` (OneToMany), `likeCount`/`scrapCount` 추가, `replaceImages()` 추가 |
| `PassportCreateRequest.java` | `imageUrl` → `imageUrls` (List) |
| `PassportUpdateRequest.java` | 동일 변경 |
| `PassportResponse.java` | `imageUrls` (List) + `likeCount`/`scrapCount` 추가 |
| `PassportService.java` | 상세 조회 + visibility 접근 제어 + `getPassportWithReadCheck()` 추가 |
| `PassportController.java` | `GET /{passportId}` 엔드포인트 추가 |
| `ScrapRepository.java` | 커서 조회 쿼리, 중복 체크/취소 메서드 추가 |
| `ErrorCode.java` | `LIKE_NOT_FOUND` (L001), `LIKE_DUPLICATE` (L002) 추가 |

## ⚠️ DB 변경 사항
- `passport.image_url` 컬럼 수동 DROP 필요 (Hibernate ddl-auto는 컬럼 삭제 안 함)
- `passport_image` 테이블 자동 생성
- `likes` 테이블 자동 생성
- `passport.like_count`, `passport.scrap_count` 컬럼 추가

```sql
-- 기존 환경에서 필요한 수동 마이그레이션
ALTER TABLE passport DROP COLUMN IF EXISTS image_url;
ALTER TABLE passport ADD COLUMN IF NOT EXISTS like_count BIGINT NOT NULL DEFAULT 0;
ALTER TABLE passport ADD COLUMN IF NOT EXISTS scrap_count BIGINT NOT NULL DEFAULT 0;
```

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

## 💬 리뷰 포인트
1. **커서 기반 페이징** — JPQL에서 `LIMIT` 사용 (Hibernate 6+ 지원). 문제 시 `Pageable` 방식으로 전환 가능.
2. **좋아요 API 미구현** — Like 엔티티 + ErrorCode만 준비해둔 상태. 다음 PR에서 구현 예정.
3. **비정규화 카운트** — `likeCount`/`scrapCount`는 동시성 이슈 가능성 있음. 트래픽 늘면 `@Version` 낙관적 락 또는 `UPDATE SET like_count = like_count + 1` 쿼리 방식 검토 필요.

