### PR TITLE
FEAT: OAuth2 로그인 성공 시 딥링크 리다이렉트 방식으로 변경

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -19,6 +19,10 @@ public class UserService {
     private final UserRepository userRepository;
     private final AuthRepository authRepository;
 
+    public boolean existsBySocialInfo(String socialId, SocialType socialType) {
+        return authRepository.findBySocialIdAndSocialType(socialId, socialType).isPresent();
+    }
+
     public Auth findOrCreateUser(OAuth2UserInfo oAuth2UserInfo, SocialType socialType) {
         return authRepository
                 .findBySocialIdAndSocialType(oAuth2UserInfo.getProviderId(), socialType)

--- a/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2User.java
@@ -15,11 +15,13 @@ public class CustomOAuth2User implements OAuth2User {
     private final Auth auth;
     private final OAuth2UserInfo oAuth2UserInfo;
     private final Map<String, Object> attributes;
+    private final boolean isNewUser;
 
-    public CustomOAuth2User(Auth auth, OAuth2UserInfo oAuth2UserInfo, Map<String, Object> attributes) {
+    public CustomOAuth2User(Auth auth, OAuth2UserInfo oAuth2UserInfo, Map<String, Object> attributes, boolean isNewUser) {
         this.auth = auth;
         this.oAuth2UserInfo = oAuth2UserInfo;
         this.attributes = attributes;
+        this.isNewUser = isNewUser;
     }
 
     @Override
@@ -51,5 +53,9 @@ public class CustomOAuth2User implements OAuth2User {
 
     public SocialType getSocialType() {
         return auth.getSocialType();
+    }
+
+    public boolean isNewUser() {
+        return isNewUser;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/CustomOAuth2UserService.java
@@ -19,15 +19,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        // OAuth2 제공자로부터 사용자 정보 가져오기
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        // 제공자 이름 가져오기 (kakao)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
         OAuth2UserInfo oAuth2UserInfo;
 
-        // 카카오 사용자 정보 파싱 - 추후 다른 제공자 추가 시 분기 예정
         if (registrationId.equals("kakao")) {
             oAuth2UserInfo = new KakaoOAuth2UserInfo(oAuth2User.getAttributes());
         } else {
@@ -36,9 +33,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         SocialType socialType = SocialType.valueOf(registrationId.toUpperCase());
 
+        boolean isNewUser = !userService.existsBySocialInfo(oAuth2UserInfo.getProviderId(), socialType);
+
         Auth auth = userService.findOrCreateUser(oAuth2UserInfo, socialType);
 
-        // CustomOAuth2User 반환
-        return new CustomOAuth2User(auth, oAuth2UserInfo, oAuth2User.getAttributes());
+        return new CustomOAuth2User(auth, oAuth2UserInfo, oAuth2User.getAttributes(), isNewUser);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
@@ -1,7 +1,5 @@
 package com.kauniv.lightrip.global.oauth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kauniv.lightrip.global.auth.dto.LoginResponse;
 import com.kauniv.lightrip.global.auth.entity.Auth;
 import com.kauniv.lightrip.global.auth.repository.AuthRepository;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
@@ -21,7 +19,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JwtProvider jwtProvider;
     private final AuthRepository authRepository;
-    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
@@ -42,13 +39,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .orElseThrow(() -> new RuntimeException("Auth를 찾을 수 없습니다."));
         auth.updateRefreshToken(refreshToken);
 
-        response.setContentType("application/json;charset=UTF-8");
+        boolean isNewUser = oAuth2User.isNewUser();
 
-        LoginResponse loginResponse = LoginResponse.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
+        String deepLink = String.format(
+                "lightrip://auth/callback?accessToken=%s&refreshToken=%s&isNewUser=%s",
+                accessToken, refreshToken, isNewUser
+        );
 
-        response.getWriter().write(objectMapper.writeValueAsString(loginResponse));
+        getRedirectStrategy().sendRedirect(request, response, deepLink);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #23 

## 📋 작업 내용

- [x] OAuth2SuccessHandler: JSON 응답 → 딥링크(lightrip://auth/callback) 리다이렉트로 변경
- [x] CustomOAuth2User: isNewUser 필드 추가
- [x] CustomOAuth2UserService: 로그인 시 신규/기존 유저 판별 로직 추가
- [x] UserService: existsBySocialInfo() 메서드 추가

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
