### PR TITLE
FEAT: 친구 요청/수락/거절/삭제 API 구현

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,7 @@ DB_PASSWORD=Lightrip1!
 DDL_AUTO=update
 SHOW_SQL=true
 FLYWAY_ENABLED=false
+
+# Sentry
+SENTRY_DSN=https://895270173ac077896a5a4c0e13bac1d8@o4511320907972608.ingest.us.sentry.io/4511320921341952
+SENTRY_AUTH_TOKEN=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

--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -12,6 +12,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "친구 관리 API", description = "친구 요청, 수락/거절, 삭제 기능을 제공합니다.")
 @RestController
 @RequestMapping("/api/v1/friends")
 @RequiredArgsConstructor
@@ -19,6 +23,7 @@ public class FriendController {
 
     private final FriendService friendService;
 
+    @Operation(summary = "친구 요청 보내기", description = "친구 코드로 상대방에게 친구 요청을 보냅니다.")
     @PostMapping("/request")
     public ResponseEntity<FriendResponseDto> sendRequest(
             @AuthenticationPrincipal CustomOAuth2User user,
@@ -28,6 +33,7 @@ public class FriendController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @Operation(summary = "친구 요청 수락/거절", description = "받은 친구 요청을 수락(ACCEPT) 또는 거절(REJECT)합니다.")
     @PatchMapping("/{friendId}")
     public ResponseEntity<?> handleRequest(
             @AuthenticationPrincipal CustomOAuth2User user,
@@ -42,6 +48,7 @@ public class FriendController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "친구 삭제", description = "친구 관계를 삭제합니다. 양쪽 당사자 모두 삭제 가능합니다.")
     @DeleteMapping("/{friendId}")
     public ResponseEntity<Void> deleteFriend(
             @AuthenticationPrincipal CustomOAuth2User user,

--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -1,0 +1,53 @@
+package com.kauniv.lightrip.domain.friend.controller;
+
+import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
+import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
+import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
+import com.kauniv.lightrip.domain.friend.service.FriendService;
+import com.kauniv.lightrip.global.oauth.CustomOAuth2User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/friends")
+@RequiredArgsConstructor
+public class FriendController {
+
+    private final FriendService friendService;
+
+    @PostMapping("/request")
+    public ResponseEntity<FriendResponseDto> sendRequest(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @Valid @RequestBody FriendRequestDto dto) {
+
+        FriendResponseDto response = friendService.sendRequest(user.getUserId(), dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{friendId}")
+    public ResponseEntity<?> handleRequest(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @PathVariable Long friendId,
+            @Valid @RequestBody FriendStatusUpdateDto dto) {
+
+        FriendResponseDto response = friendService.handleRequest(user.getUserId(), friendId, dto);
+
+        if (response == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{friendId}")
+    public ResponseEntity<Void> deleteFriend(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @PathVariable Long friendId) {
+
+        friendService.deleteFriend(user.getUserId(), friendId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendRequestDto.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendRequestDto.java
@@ -1,0 +1,8 @@
+package com.kauniv.lightrip.domain.friend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FriendRequestDto(
+        @NotBlank(message = "친구 코드는 필수입니다.")
+        String friendCode
+) {}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendStatusUpdateDto.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendStatusUpdateDto.java
@@ -1,0 +1,8 @@
+package com.kauniv.lightrip.domain.friend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FriendStatusUpdateDto(
+        @NotBlank(message = "액션은 필수입니다.")
+        String action
+) {}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponseDto.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponseDto.java
@@ -1,0 +1,28 @@
+package com.kauniv.lightrip.domain.friend.dto.response;
+
+import com.kauniv.lightrip.domain.friend.entity.Friend;
+import com.kauniv.lightrip.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record FriendResponseDto(
+        Long friendId,
+        Long userId,
+        String nickname,
+        String profileImg,
+        String friendCode,
+        String status,
+        LocalDateTime createdAt
+) {
+    public static FriendResponseDto from(Friend friend, User target) {
+        return new FriendResponseDto(
+                friend.getId(),
+                target.getId(),
+                target.getNickname(),
+                target.getProfileImg(),
+                target.getFriendCode(),
+                friend.getStatus().name(),
+                friend.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/entity/Friend.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/entity/Friend.java
@@ -43,4 +43,8 @@ public class Friend {
     public enum Status {
         PENDING, ACCEPTED
     }
+
+    public void accept() {
+        this.status = Status.ACCEPTED;
+    }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
@@ -3,6 +3,7 @@ package com.kauniv.lightrip.domain.friend.repository;
 import com.kauniv.lightrip.domain.friend.entity.Friend;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
@@ -12,5 +13,12 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
               AND ((f.requester.id = :userA AND f.receiver.id = :userB)
                 OR (f.requester.id = :userB AND f.receiver.id = :userA))
             """)
-    boolean isFriend(Long userA, Long userB);
+    boolean isFriend(@Param("userA") Long userA, @Param("userB") Long userB);
+
+    @Query("""
+            SELECT COUNT(f) > 0 FROM Friend f
+            WHERE (f.requester.id = :userA AND f.receiver.id = :userB)
+               OR (f.requester.id = :userB AND f.receiver.id = :userA)
+            """)
+    boolean existsFriendship(@Param("userA") Long userA, @Param("userB") Long userB);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -1,0 +1,80 @@
+package com.kauniv.lightrip.domain.friend.service;
+
+import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
+import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
+import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
+import com.kauniv.lightrip.domain.friend.entity.Friend;
+import com.kauniv.lightrip.domain.friend.repository.FriendRepository;
+import com.kauniv.lightrip.domain.user.entity.User;
+import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FriendService {
+
+    private final FriendRepository friendRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public FriendResponseDto sendRequest(Long requesterId, FriendRequestDto dto) {
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        User receiver = userRepository.findByFriendCode(dto.friendCode())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (requester.getId().equals(receiver.getId())) {
+            throw new BusinessException(ErrorCode.FRIEND_SELF_REQUEST);
+        }
+
+        if (friendRepository.existsFriendship(requester.getId(), receiver.getId())) {
+            throw new BusinessException(ErrorCode.FRIEND_ALREADY_REQUESTED);
+        }
+
+        Friend friend = Friend.builder()
+                .requester(requester)
+                .receiver(receiver)
+                .status(Friend.Status.PENDING)
+                .build();
+
+        friendRepository.save(friend);
+        return FriendResponseDto.from(friend, receiver);
+    }
+
+    @Transactional
+    public FriendResponseDto handleRequest(Long userId, Long friendId, FriendStatusUpdateDto dto) {
+        Friend friend = friendRepository.findById(friendId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FRIEND_NOT_FOUND));
+
+        if (!friend.getReceiver().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FRIEND_NOT_RECEIVER);
+        }
+
+        if ("ACCEPT".equalsIgnoreCase(dto.action())) {
+            friend.accept();
+            return FriendResponseDto.from(friend, friend.getRequester());
+        } else {
+            friendRepository.delete(friend);
+            return null;
+        }
+    }
+
+    @Transactional
+    public void deleteFriend(Long userId, Long friendId) {
+        Friend friend = friendRepository.findById(friendId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FRIEND_NOT_FOUND));
+
+        if (!friend.getRequester().getId().equals(userId)
+                && !friend.getReceiver().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FRIEND_NOT_MEMBER);
+        }
+
+        friendRepository.delete(friend);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(name = "users")
@@ -29,6 +30,9 @@ public class User {
     @Column(name = "profile_img", columnDefinition = "TEXT")
     private String profileImg;
 
+    @Column(name = "friend_code", nullable = false, unique = true, length = 8)
+    private String friendCode;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "current_mode")
     private CurrentMode currentMode;
@@ -40,4 +44,11 @@ public class User {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @PrePersist
+    private void generateFriendCode() {
+        if (this.friendCode == null) {
+            this.friendCode = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        }
+    }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/repository/UserRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByEmail(String email);
+    Optional<User> findByFriendCode(String friendCode);
 }

--- a/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
@@ -2,11 +2,14 @@ package com.kauniv.lightrip.global.auth.controller;
 
 import com.kauniv.lightrip.global.auth.dto.TokenResponse;
 import com.kauniv.lightrip.global.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "인증 API", description = "토큰 재발급, 로그아웃, 회원탈퇴 기능을 제공합니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -14,6 +17,7 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰으로 새 액세스 토큰을 발급받습니다.")
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
             @RequestHeader("Refresh-Token") String refreshToken) {
@@ -25,6 +29,7 @@ public class AuthController {
         );
     }
 
+    @Operation(summary = "로그아웃", description = "리프레시 토큰을 무효화하여 로그아웃 처리합니다.")
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
             @AuthenticationPrincipal Long userId) {
@@ -32,6 +37,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "회원탈퇴", description = "유저 및 관련 인증 정보를 모두 삭제합니다.")
     @DeleteMapping("/withdraw")
     public ResponseEntity<Void> withdraw(
             @AuthenticationPrincipal Long userId) {

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -43,7 +43,14 @@ public enum ErrorCode {
 
     // ===== Like =====
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "좋아요 기록이 존재하지 않습니다."),
-    LIKE_DUPLICATE(HttpStatus.CONFLICT, "L002", "이미 좋아요한 여권입니다.");
+    LIKE_DUPLICATE(HttpStatus.CONFLICT, "L002", "이미 좋아요한 여권입니다."),
+
+    // ===== Friend =====
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "친구 요청을 찾을 수 없습니다."),
+    FRIEND_ALREADY_REQUESTED(HttpStatus.CONFLICT, "F002", "이미 친구 요청을 보냈거나 친구 관계입니다."),
+    FRIEND_SELF_REQUEST(HttpStatus.BAD_REQUEST, "F003", "자기 자신에게 친구 요청을 보낼 수 없습니다."),
+    FRIEND_NOT_RECEIVER(HttpStatus.FORBIDDEN, "F004", "친구 요청을 수락/거절할 권한이 없습니다."),
+    FRIEND_NOT_MEMBER(HttpStatus.FORBIDDEN, "F005", "해당 친구 관계의 당사자가 아닙니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 
 # JWT
 jwt.secret=${JWT_SECRET}
-jwt.access-token-expiration=3600000
+jwt.access-token-expiration=10800000
 jwt.refresh-token-expiration=1209600000
 
 # PostgreSQL


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #29

## 📝 작업 내용

- [x] User 엔티티에 friendCode 필드 및 @PrePersist 자동 생성 추가
- [x] UserRepository에 findByFriendCode 메서드 추가
- [x] Friend 엔티티에 accept() 상태 변경 메서드 추가
- [x] FriendRepository에 existsFriendship 양방향 중복 체크 쿼리 추가
- [x] ErrorCode에 Friend 관련 에러코드 추가 (F001~F005)
- [x] FriendRequestDto, FriendStatusUpdateDto, FriendResponseDto 생성
- [x] FriendService 생성 (요청/수락/거절/삭제 비즈니스 로직)
- [x] FriendController 생성 (POST/PATCH/DELETE 엔드포인트)

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.
