### PR TITLE
FIX: FriendController 인증 타입 수정 (CustomOAuth2User → Long userId)

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -4,7 +4,6 @@ import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
 import com.kauniv.lightrip.domain.friend.service.FriendService;
-import com.kauniv.lightrip.global.oauth.CustomOAuth2User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,21 +25,21 @@ public class FriendController {
     @Operation(summary = "친구 요청 보내기", description = "친구 코드로 상대방에게 친구 요청을 보냅니다.")
     @PostMapping("/request")
     public ResponseEntity<FriendResponseDto> sendRequest(
-            @AuthenticationPrincipal CustomOAuth2User user,
+            @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FriendRequestDto dto) {
 
-        FriendResponseDto response = friendService.sendRequest(user.getUserId(), dto);
+        FriendResponseDto response = friendService.sendRequest(userId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @Operation(summary = "친구 요청 수락/거절", description = "받은 친구 요청을 수락(ACCEPT) 또는 거절(REJECT)합니다.")
     @PatchMapping("/{friendId}")
     public ResponseEntity<?> handleRequest(
-            @AuthenticationPrincipal CustomOAuth2User user,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long friendId,
             @Valid @RequestBody FriendStatusUpdateDto dto) {
 
-        FriendResponseDto response = friendService.handleRequest(user.getUserId(), friendId, dto);
+        FriendResponseDto response = friendService.handleRequest(userId, friendId, dto);
 
         if (response == null) {
             return ResponseEntity.noContent().build();
@@ -51,10 +50,10 @@ public class FriendController {
     @Operation(summary = "친구 삭제", description = "친구 관계를 삭제합니다. 양쪽 당사자 모두 삭제 가능합니다.")
     @DeleteMapping("/{friendId}")
     public ResponseEntity<Void> deleteFriend(
-            @AuthenticationPrincipal CustomOAuth2User user,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long friendId) {
 
-        friendService.deleteFriend(user.getUserId(), friendId);
+        friendService.deleteFriend(userId, friendId);
         return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #29

## 📝 작업 내용

- [x] FriendController 인증 타입 수정 (CustomOAuth2User → Long userId)
- [x] 액세스 토큰 만료 시간 변경 (1시간 → 3시간)

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

