### PR TITLE
FEAT: 여권 좋아요 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/like/controller/LikeController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/like/controller/LikeController.java
@@ -1,0 +1,55 @@
+package com.kauniv.lightrip.domain.like.controller;
+
+import com.kauniv.lightrip.domain.like.dto.response.LikeListResponse;
+import com.kauniv.lightrip.domain.like.dto.response.LikeResponse;
+import com.kauniv.lightrip.domain.like.service.LikeService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import com.kauniv.lightrip.global.common.response.CursorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Like", description = "여권 좋아요 API")
+@RestController
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @Operation(summary = "좋아요 등록",
+            description = "여권에 좋아요를 등록합니다. 본인 여권도 좋아요 가능. 중복 좋아요 불가.")
+    @PostMapping("/api/v1/passports/{passportId}/likes")
+    public ApiResponse<LikeResponse> create(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId
+    ) {
+        return ApiResponse.success("좋아요가 등록되었습니다.", likeService.create(userId, passportId));
+    }
+
+    @Operation(summary = "좋아요 취소",
+            description = "여권 좋아요를 취소합니다.")
+    @DeleteMapping("/api/v1/passports/{passportId}/likes")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId
+    ) {
+        likeService.delete(userId, passportId);
+        return ApiResponse.success("좋아요가 취소되었습니다.", null);
+    }
+
+    @Operation(summary = "내 좋아요 목록 조회",
+            description = "내가 좋아요한 여권 목록을 커서 기반으로 조회합니다.")
+    @GetMapping("/api/v1/passports/likes/me")
+    public ApiResponse<CursorResponse<LikeListResponse>> getMyLikes(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "커서 (마지막 좋아요 ID, 첫 요청 시 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "조회 개수 (기본 10)")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.success(likeService.getMyLikes(userId, cursor, size));
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/like/dto/response/LikeListResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/like/dto/response/LikeListResponse.java
@@ -1,0 +1,58 @@
+package com.kauniv.lightrip.domain.like.dto.response;
+
+import com.kauniv.lightrip.domain.like.entity.Like;
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "좋아요 목록 항목")
+public record LikeListResponse(
+
+        @Schema(description = "좋아요 ID (커서로 사용)")
+        Long likeId,
+
+        @Schema(description = "좋아요 생성일시")
+        LocalDateTime likeCreatedAt,
+
+        @Schema(description = "여권 ID")
+        Long passportId,
+
+        @Schema(description = "대표 이미지 URL (첫 번째 이미지)")
+        String thumbnailUrl,
+
+        @Schema(description = "기록 내용")
+        String content,
+
+        @Schema(description = "주소")
+        String address,
+
+        @Schema(description = "위치명")
+        String spaceName,
+
+        @Schema(description = "좋아요 수")
+        Long likeCount,
+
+        @Schema(description = "스크랩 수")
+        Long scrapCount
+) {
+    public static LikeListResponse from(Like like) {
+        Passport p = like.getPassport();
+
+        String thumbnail = p.getImages().isEmpty()
+                ? null
+                : p.getImages().get(0).getImageUrl();
+
+        return new LikeListResponse(
+                like.getId(),
+                like.getCreatedAt(),
+                p.getId(),
+                thumbnail,
+                p.getContent(),
+                p.getAddress(),
+                p.getSpaceName(),
+                p.getLikeCount(),
+                p.getScrapCount()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/like/dto/response/LikeResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/like/dto/response/LikeResponse.java
@@ -1,0 +1,21 @@
+package com.kauniv.lightrip.domain.like.dto.response;
+
+import com.kauniv.lightrip.domain.like.entity.Like;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "좋아요 응답")
+public record LikeResponse(
+        Long likeId,
+        Long passportId,
+        LocalDateTime createdAt
+) {
+    public static LikeResponse from(Like like) {
+        return new LikeResponse(
+                like.getId(),
+                like.getPassport().getId(),
+                like.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/like/repository/LikeRepository.java
@@ -1,9 +1,41 @@
 package com.kauniv.lightrip.domain.like.repository;
 
 import com.kauniv.lightrip.domain.like.entity.Like;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    @Modifying
+    @Query("DELETE FROM Like l WHERE l.passport.id = :passportId")
+    void deleteAllByPassportId(Long passportId);
+
+    boolean existsByUser_IdAndPassport_Id(Long userId, Long passportId);
+
+    Optional<Like> findByUser_IdAndPassport_Id(Long userId, Long passportId);
+
+    @Query("""
+            SELECT l FROM Like l
+            JOIN FETCH l.passport p
+            LEFT JOIN FETCH p.images
+            WHERE l.user.id = :userId
+            ORDER BY l.id DESC
+            """)
+    List<Like> findByUserIdFirst(Long userId, Pageable pageable);
+
+    @Query("""
+            SELECT l FROM Like l
+            JOIN FETCH l.passport p
+            LEFT JOIN FETCH p.images
+            WHERE l.user.id = :userId AND l.id < :cursor
+            ORDER BY l.id DESC
+            """)
+    List<Like> findByUserIdAfterCursor(Long userId, Long cursor, Pageable pageable);
 
     long countByUser_Id(Long userId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/like/service/LikeService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/like/service/LikeService.java
@@ -1,0 +1,86 @@
+package com.kauniv.lightrip.domain.like.service;
+
+import com.kauniv.lightrip.domain.like.dto.response.LikeListResponse;
+import com.kauniv.lightrip.domain.like.dto.response.LikeResponse;
+import com.kauniv.lightrip.domain.like.entity.Like;
+import com.kauniv.lightrip.domain.like.repository.LikeRepository;
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
+import com.kauniv.lightrip.domain.user.entity.User;
+import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import com.kauniv.lightrip.global.common.response.CursorResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final PassportRepository passportRepository;
+    private final UserRepository userRepository;
+
+    // ========== 좋아요 등록 ==========
+    @Transactional
+    public LikeResponse create(Long userId, Long passportId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Passport passport = passportRepository.findById(passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
+
+        if (likeRepository.existsByUser_IdAndPassport_Id(userId, passportId)) {
+            throw new BusinessException(ErrorCode.LIKE_DUPLICATE);
+        }
+
+        Like like = Like.builder()
+                .user(user)
+                .passport(passport)
+                .build();
+
+        likeRepository.save(like);
+        passport.increaseLikeCount();
+
+        return LikeResponse.from(like);
+    }
+
+    // ========== 좋아요 취소 ==========
+    @Transactional
+    public void delete(Long userId, Long passportId) {
+        Like like = likeRepository.findByUser_IdAndPassport_Id(userId, passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.LIKE_NOT_FOUND));
+
+        Passport passport = like.getPassport();
+
+        likeRepository.delete(like);
+        passport.decreaseLikeCount();
+    }
+
+    // ========== 내 좋아요 목록 조회 ==========
+    public CursorResponse<LikeListResponse> getMyLikes(Long userId, Long cursor, int size) {
+        List<Like> likes = (cursor == null)
+                ? likeRepository.findByUserIdFirst(userId, PageRequest.of(0, size + 1))
+                : likeRepository.findByUserIdAfterCursor(userId, cursor, PageRequest.of(0, size + 1));
+
+        boolean hasNext = likes.size() > size;
+
+        if (hasNext) {
+            likes = likes.subList(0, size);
+        }
+
+        List<LikeListResponse> content = likes.stream()
+                .map(LikeListResponse::from)
+                .toList();
+
+        Long nextCursor = hasNext ? likes.get(likes.size() - 1).getId() : null;
+
+        return CursorResponse.of(content, hasNext, nextCursor);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -134,6 +134,7 @@ public class PassportService {
 
         District district = passport.getDistrictCategory();
 
+        likeRepository.deleteAllByPassportId(passportId);
         scrapRepository.deleteAllByPassportId(passportId);
         passportRepository.delete(passport);
         passportRepository.flush();


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #32 

## 📝 작업 내용

여권 좋아요 등록/취소 및 좋아요한 여권 목록 조회 API 구현

- `LikeRepository` 메서드 추가 (existsBy, findBy, 커서 페이징, deleteAllByPassportId)
- `LikeResponse`, `LikeListResponse` DTO 작성
- `LikeService`, `LikeController` 신규 생성
- 좋아요 등록/취소 시 `Passport.like_count` 자동 증감
- 중복 좋아요 등록 방지 (LIKE_DUPLICATE)
- 여권 삭제 시 좋아요 기록 일괄 삭제 처리 추가

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.