### PR TITLE
FEAT: 친구 목록/받은 요청/코드 검색 조회 API 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 env:
   AWS_REGION: ap-northeast-2
@@ -33,11 +33,12 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.ref_name }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.ref_name }}
 
-      - name: Deploy to EC2
+      - name: Deploy to EC2 (prod)
+        if: github.ref_name == 'main'
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -48,16 +49,42 @@ jobs:
             aws ecr get-login-password --region ap-northeast-2 | \
               docker login --username AWS --password-stdin $ECR_REGISTRY
 
-            docker pull $ECR_REGISTRY/lightrip-server:latest
+            docker pull $ECR_REGISTRY/lightrip-server:main
 
-            docker stop lightrip-server || true
-            docker rm lightrip-server || true
+            docker stop lightrip-prod || true
+            docker rm lightrip-prod || true
 
             docker run -d \
-              --name lightrip-server \
+              --name lightrip-prod \
               --restart always \
               -p 8080:8080 \
               --env-file /home/ec2-user/.env \
-              $ECR_REGISTRY/lightrip-server:latest
+              $ECR_REGISTRY/lightrip-server:main
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+
+      - name: Deploy to EC2 (dev)
+        if: github.ref_name == 'develop'
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          envs: ECR_REGISTRY
+          script: |
+            aws ecr get-login-password --region ap-northeast-2 | \
+              docker login --username AWS --password-stdin $ECR_REGISTRY
+
+            docker pull $ECR_REGISTRY/lightrip-server:develop
+
+            docker stop lightrip-dev || true
+            docker rm lightrip-dev || true
+
+            docker run -d \
+              --name lightrip-dev \
+              --restart always \
+              -p 8081:8080 \
+              --env-file /home/ec2-user/.env.dev \
+              $ECR_REGISTRY/lightrip-server:develop
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -4,7 +4,6 @@ import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
 import com.kauniv.lightrip.domain.friend.service.FriendService;
-import com.kauniv.lightrip.global.oauth.CustomOAuth2User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +14,9 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "친구 관리 API", description = "친구 요청, 수락/거절, 삭제 기능을 제공합니다.")
+import java.util.List;
+
+@Tag(name = "친구 관리 API", description = "친구 요청, 수락/거절, 삭제, 조회 기능을 제공합니다.")
 @RestController
 @RequestMapping("/api/v1/friends")
 @RequiredArgsConstructor
@@ -26,21 +27,21 @@ public class FriendController {
     @Operation(summary = "친구 요청 보내기", description = "친구 코드로 상대방에게 친구 요청을 보냅니다.")
     @PostMapping("/request")
     public ResponseEntity<FriendResponseDto> sendRequest(
-            @AuthenticationPrincipal CustomOAuth2User user,
+            @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FriendRequestDto dto) {
 
-        FriendResponseDto response = friendService.sendRequest(user.getUserId(), dto);
+        FriendResponseDto response = friendService.sendRequest(userId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @Operation(summary = "친구 요청 수락/거절", description = "받은 친구 요청을 수락(ACCEPT) 또는 거절(REJECT)합니다.")
     @PatchMapping("/{friendId}")
     public ResponseEntity<?> handleRequest(
-            @AuthenticationPrincipal CustomOAuth2User user,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long friendId,
             @Valid @RequestBody FriendStatusUpdateDto dto) {
 
-        FriendResponseDto response = friendService.handleRequest(user.getUserId(), friendId, dto);
+        FriendResponseDto response = friendService.handleRequest(userId, friendId, dto);
 
         if (response == null) {
             return ResponseEntity.noContent().build();
@@ -51,10 +52,37 @@ public class FriendController {
     @Operation(summary = "친구 삭제", description = "친구 관계를 삭제합니다. 양쪽 당사자 모두 삭제 가능합니다.")
     @DeleteMapping("/{friendId}")
     public ResponseEntity<Void> deleteFriend(
-            @AuthenticationPrincipal CustomOAuth2User user,
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long friendId) {
 
-        friendService.deleteFriend(user.getUserId(), friendId);
+        friendService.deleteFriend(userId, friendId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "내 친구 목록 조회", description = "수락된 친구 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<FriendResponseDto>> getFriends(
+            @AuthenticationPrincipal Long userId) {
+
+        List<FriendResponseDto> response = friendService.getFriends(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "받은 친구 요청 조회", description = "아직 수락하지 않은 친구 요청 목록을 조회합니다.")
+    @GetMapping("/pending")
+    public ResponseEntity<List<FriendResponseDto>> getPendingRequests(
+            @AuthenticationPrincipal Long userId) {
+
+        List<FriendResponseDto> response = friendService.getPendingRequests(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "친구 코드로 유저 검색", description = "친구 코드로 유저를 검색합니다. 친구 요청 전 상대방 확인용입니다.")
+    @GetMapping("/search")
+    public ResponseEntity<FriendResponseDto> searchByFriendCode(
+            @RequestParam String code) {
+
+        FriendResponseDto response = friendService.searchByFriendCode(code);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     @Query("""
@@ -21,4 +23,18 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
                OR (f.requester.id = :userB AND f.receiver.id = :userA)
             """)
     boolean existsFriendship(@Param("userA") Long userA, @Param("userB") Long userB);
+
+    @Query("""
+            SELECT f FROM Friend f
+            WHERE f.status = 'ACCEPTED'
+              AND (f.requester.id = :userId OR f.receiver.id = :userId)
+            """)
+    List<Friend> findAllFriends(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT f FROM Friend f
+            WHERE f.status = 'PENDING'
+              AND f.receiver.id = :userId
+            """)
+    List<Friend> findPendingRequests(@Param("userId") Long userId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -76,5 +78,41 @@ public class FriendService {
         }
 
         friendRepository.delete(friend);
+    }
+
+    public List<FriendResponseDto> getFriends(Long userId) {
+        List<Friend> friends = friendRepository.findAllFriends(userId);
+
+        return friends.stream()
+                .map(friend -> {
+                    User target = friend.getRequester().getId().equals(userId)
+                            ? friend.getReceiver()
+                            : friend.getRequester();
+                    return FriendResponseDto.from(friend, target);
+                })
+                .toList();
+    }
+
+    public List<FriendResponseDto> getPendingRequests(Long userId) {
+        List<Friend> pendings = friendRepository.findPendingRequests(userId);
+
+        return pendings.stream()
+                .map(friend -> FriendResponseDto.from(friend, friend.getRequester()))
+                .toList();
+    }
+
+    public FriendResponseDto searchByFriendCode(String friendCode) {
+        User user = userRepository.findByFriendCode(friendCode)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return new FriendResponseDto(
+                null,
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImg(),
+                user.getFriendCode(),
+                null,
+                null
+        );
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #34 

- [x] 내 친구 목록 조회 API (GET /api/v1/friends)
- [x] 받은 친구 요청 조회 API (GET /api/v1/friends/pending)
- [x] 친구 코드로 유저 검색 API (GET /api/v1/friends/search?code={code})
- [x] FriendRepository에 findAllFriends, findPendingRequests 쿼리 추가
- [x] FriendService에 getFriends, getPendingRequests, searchByFriendCode 로직 추가
- [x] FriendController에 GET 엔드포인트 3개 추가

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

