### PR TITLE
FEAT: 유저 프로필 조회 및 작성 API 구현

### DIFF
--- a/.env
+++ b/.env
@@ -19,3 +19,6 @@ FLYWAY_ENABLED=false
 # Sentry
 SENTRY_DSN=https://895270173ac077896a5a4c0e13bac1d8@o4511320907972608.ingest.us.sentry.io/4511320921341952
 SENTRY_AUTH_TOKEN=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
+
+# 엑세스 토큰 용 로그 레벨
+LOGGING_LEVEL=DEBUG

--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -4,6 +4,7 @@ import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
 import com.kauniv.lightrip.domain.friend.service.FriendService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,12 +27,12 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 보내기", description = "친구 코드로 상대방에게 친구 요청을 보냅니다.")
     @PostMapping("/request")
-    public ResponseEntity<FriendResponseDto> sendRequest(
+    public ResponseEntity<ApiResponse<FriendResponseDto>> sendRequest(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FriendRequestDto dto) {
 
         FriendResponseDto response = friendService.sendRequest(userId, dto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
     @Operation(summary = "친구 요청 수락/거절", description = "받은 친구 요청을 수락(ACCEPT) 또는 거절(REJECT)합니다.")
@@ -46,43 +47,43 @@ public class FriendController {
         if (response == null) {
             return ResponseEntity.noContent().build();
         }
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "친구 삭제", description = "친구 관계를 삭제합니다. 양쪽 당사자 모두 삭제 가능합니다.")
     @DeleteMapping("/{friendId}")
-    public ResponseEntity<Void> deleteFriend(
+    public ApiResponse<Void> deleteFriend(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long friendId) {
 
         friendService.deleteFriend(userId, friendId);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.success("친구 관계가 삭제되었습니다.", null);
     }
 
     @Operation(summary = "내 친구 목록 조회", description = "수락된 친구 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<FriendResponseDto>> getFriends(
+    public ApiResponse<List<FriendResponseDto>> getFriends(
             @AuthenticationPrincipal Long userId) {
 
         List<FriendResponseDto> response = friendService.getFriends(userId);
-        return ResponseEntity.ok(response);
+        return ApiResponse.success(response);
     }
 
     @Operation(summary = "받은 친구 요청 조회", description = "아직 수락하지 않은 친구 요청 목록을 조회합니다.")
     @GetMapping("/pending")
-    public ResponseEntity<List<FriendResponseDto>> getPendingRequests(
+    public ApiResponse<List<FriendResponseDto>> getPendingRequests(
             @AuthenticationPrincipal Long userId) {
 
         List<FriendResponseDto> response = friendService.getPendingRequests(userId);
-        return ResponseEntity.ok(response);
+        return ApiResponse.success(response);
     }
 
     @Operation(summary = "친구 코드로 유저 검색", description = "친구 코드로 유저를 검색합니다. 친구 요청 전 상대방 확인용입니다.")
     @GetMapping("/search")
-    public ResponseEntity<FriendResponseDto> searchByFriendCode(
+    public ApiResponse<FriendResponseDto> searchByFriendCode(
             @RequestParam String code) {
 
         FriendResponseDto response = friendService.searchByFriendCode(code);
-        return ResponseEntity.ok(response);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendAction.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendAction.java
@@ -1,0 +1,6 @@
+package com.kauniv.lightrip.domain.friend.dto.request;
+
+public enum FriendAction {
+    ACCEPT,
+    REJECT
+}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendStatusUpdateDto.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendStatusUpdateDto.java
@@ -1,8 +1,10 @@
 package com.kauniv.lightrip.domain.friend.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public record FriendStatusUpdateDto(
-        @NotBlank(message = "액션은 필수입니다.")
-        String action
+        @Schema(description = "친구 요청 처리 액션", allowableValues = {"ACCEPT", "REJECT"}, example = "ACCEPT")
+        @NotNull(message = "액션은 필수입니다.")
+        FriendAction action
 ) {}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -1,5 +1,6 @@
 package com.kauniv.lightrip.domain.friend.service;
 
+import com.kauniv.lightrip.domain.friend.dto.request.FriendAction;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
@@ -58,7 +59,7 @@ public class FriendService {
             throw new BusinessException(ErrorCode.FRIEND_NOT_RECEIVER);
         }
 
-        if ("ACCEPT".equalsIgnoreCase(dto.action())) {
+        if (dto.action() == FriendAction.ACCEPT) {
             friend.accept();
             return FriendResponseDto.from(friend, friend.getRequester());
         } else {

--- a/src/main/java/com/kauniv/lightrip/domain/user/controller/UserController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/controller/UserController.java
@@ -1,0 +1,44 @@
+package com.kauniv.lightrip.domain.user.controller;
+
+import com.kauniv.lightrip.domain.user.dto.request.UpdateProfileRequest;
+import com.kauniv.lightrip.domain.user.dto.response.MyProfileResponse;
+import com.kauniv.lightrip.domain.user.dto.response.PublicProfileResponse;
+import com.kauniv.lightrip.domain.user.service.UserService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "유저 프로필 API", description = "내 프로필 조회/편집 및 공개 프로필 조회 기능을 제공합니다.")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "내 프로필 조회", description = "로그인한 본인의 전체 프로필을 조회합니다.")
+    @GetMapping("/me")
+    public ApiResponse<MyProfileResponse> getMyProfile(
+            @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(userService.getMyProfile(userId));
+    }
+
+    @Operation(summary = "내 프로필 편집", description = "닉네임과 프로필 이미지를 수정합니다.")
+    @PutMapping("/me")
+    public ApiResponse<MyProfileResponse> updateMyProfile(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody UpdateProfileRequest request) {
+        return ApiResponse.success(userService.updateMyProfile(userId, request));
+    }
+
+    @Operation(summary = "공개 프로필 조회", description = "다른 유저의 공개 프로필을 조회합니다.")
+    @GetMapping("/{userId}")
+    public ApiResponse<PublicProfileResponse> getPublicProfile(
+            @PathVariable Long userId) {
+        return ApiResponse.success(userService.getPublicProfile(userId));
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/request/UpdateProfileRequest.java
@@ -12,4 +12,10 @@ public class UpdateProfileRequest {
     private String nickname;
 
     private String profileImg;
+
+    @Size(max = 100, message = "활동 지역은 100자 이하여야 합니다.")
+    private String location;
+
+    @Size(max = 200, message = "한 줄 소개는 200자 이하여야 합니다.")
+    private String bio;
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,15 @@
+package com.kauniv.lightrip.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateProfileRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
+    private String nickname;
+
+    private String profileImg;
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
@@ -1,0 +1,31 @@
+package com.kauniv.lightrip.domain.user.dto.response;
+
+import com.kauniv.lightrip.domain.user.entity.CurrentMode;
+import com.kauniv.lightrip.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyProfileResponse {
+
+    private Long userId;
+    private String nickname;
+    private String email;
+    private String profileImg;
+    private CurrentMode currentMode;
+    private LocalDateTime createdAt;
+
+    public static MyProfileResponse from(User user) {
+        return MyProfileResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImg(user.getProfileImg())
+                .currentMode(user.getCurrentMode())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
@@ -15,17 +15,34 @@ public class MyProfileResponse {
     private String nickname;
     private String email;
     private String profileImg;
+    private String friendCode;
+    private String location;
+    private String bio;
     private CurrentMode currentMode;
     private LocalDateTime createdAt;
+    private Stats stats;
 
-    public static MyProfileResponse from(User user) {
+    @Getter
+    @Builder
+    public static class Stats {
+        private long passportCount;
+        private long friendCount;
+        private long likeCount;
+        private long scrapCount;
+    }
+
+    public static MyProfileResponse from(User user, Stats stats) {
         return MyProfileResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .profileImg(user.getProfileImg())
+                .friendCode(user.getFriendCode())
+                .location(user.getLocation())
+                .bio(user.getBio())
                 .currentMode(user.getCurrentMode())
                 .createdAt(user.getCreatedAt())
+                .stats(stats)
                 .build();
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/response/PublicProfileResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/response/PublicProfileResponse.java
@@ -1,0 +1,22 @@
+package com.kauniv.lightrip.domain.user.dto.response;
+
+import com.kauniv.lightrip.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PublicProfileResponse {
+
+    private Long userId;
+    private String nickname;
+    private String profileImg;
+
+    public static PublicProfileResponse from(User user) {
+        return PublicProfileResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImg(user.getProfileImg())
+                .build();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
@@ -37,6 +37,12 @@ public class User {
     @Column(name = "current_mode")
     private CurrentMode currentMode;
 
+    @Column(name = "location", length = 100)
+    private String location;
+
+    @Column(name = "bio", columnDefinition = "TEXT")
+    private String bio;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -55,5 +61,12 @@ public class User {
     public void updateProfile(String nickname, String profileImg) {
         this.nickname = nickname;
         this.profileImg = profileImg;
+    }
+
+    public void updateProfile(String nickname, String profileImg, String location, String bio) {
+        this.nickname = nickname;
+        this.profileImg = profileImg;
+        this.location = location;
+        this.bio = bio;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
@@ -21,7 +21,7 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(name = "nickname", nullable = false, length = 50)
+    @Column(name = "nickname", nullable = false, unique = true, length = 50)
     private String nickname;
 
     @Column(name = "email", length = 50)
@@ -50,5 +50,10 @@ public class User {
         if (this.friendCode == null) {
             this.friendCode = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
         }
+    }
+
+    public void updateProfile(String nickname, String profileImg) {
+        this.nickname = nickname;
+        this.profileImg = profileImg;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
     Optional<User> findByFriendCode(String friendCode);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -1,5 +1,9 @@
 package com.kauniv.lightrip.domain.user.service;
 
+import com.kauniv.lightrip.domain.friend.repository.FriendRepository;
+import com.kauniv.lightrip.domain.like.repository.LikeRepository;
+import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
+import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
 import com.kauniv.lightrip.domain.user.dto.response.MyProfileResponse;
 import com.kauniv.lightrip.domain.user.dto.response.PublicProfileResponse;
 import com.kauniv.lightrip.domain.user.dto.request.UpdateProfileRequest;
@@ -23,6 +27,10 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final AuthRepository authRepository;
+    private final PassportRepository passportRepository;
+    private final FriendRepository friendRepository;
+    private final LikeRepository likeRepository;
+    private final ScrapRepository scrapRepository;
 
     public boolean existsBySocialInfo(String socialId, SocialType socialType) {
         return authRepository.findBySocialIdAndSocialType(socialId, socialType).isPresent();
@@ -56,7 +64,15 @@ public class UserService {
     public MyProfileResponse getMyProfile(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        return MyProfileResponse.from(user);
+
+        MyProfileResponse.Stats stats = MyProfileResponse.Stats.builder()
+                .passportCount(passportRepository.countByUser_Id(userId))
+                .friendCount(friendRepository.findAllFriends(userId).size())
+                .likeCount(likeRepository.countByUser_Id(userId))
+                .scrapCount(scrapRepository.countByUser_Id(userId))
+                .build();
+
+        return MyProfileResponse.from(user, stats);
     }
 
     @Transactional
@@ -69,8 +85,16 @@ public class UserService {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
 
-        user.updateProfile(request.getNickname(), request.getProfileImg());
-        return MyProfileResponse.from(user);
+        user.updateProfile(request.getNickname(), request.getProfileImg(), request.getLocation(), request.getBio());
+
+        MyProfileResponse.Stats stats = MyProfileResponse.Stats.builder()
+                .passportCount(passportRepository.countByUser_Id(userId))
+                .friendCount(friendRepository.findAllFriends(userId).size())
+                .likeCount(likeRepository.countByUser_Id(userId))
+                .scrapCount(scrapRepository.countByUser_Id(userId))
+                .build();
+
+        return MyProfileResponse.from(user, stats);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -1,10 +1,15 @@
 package com.kauniv.lightrip.domain.user.service;
 
+import com.kauniv.lightrip.domain.user.dto.response.MyProfileResponse;
+import com.kauniv.lightrip.domain.user.dto.response.PublicProfileResponse;
+import com.kauniv.lightrip.domain.user.dto.request.UpdateProfileRequest;
 import com.kauniv.lightrip.global.auth.entity.Auth;
 import com.kauniv.lightrip.domain.user.entity.CurrentMode;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.global.auth.repository.AuthRepository;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.oauth.SocialType;
 import com.kauniv.lightrip.global.oauth.userinfo.OAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
@@ -45,5 +50,33 @@ public class UserService {
                         .socialType(socialType)
                         .build()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public MyProfileResponse getMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return MyProfileResponse.from(user);
+    }
+
+    @Transactional
+    public MyProfileResponse updateMyProfile(Long userId, UpdateProfileRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.getNickname().equals(request.getNickname())
+                && userRepository.existsByNickname(request.getNickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        user.updateProfile(request.getNickname(), request.getProfileImg());
+        return MyProfileResponse.from(user);
+    }
+
+    @Transactional(readOnly = true)
+    public PublicProfileResponse getPublicProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return PublicProfileResponse.from(user);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     // ===== User =====
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "U002", "이미 사용 중인 닉네임입니다."),
 
     // ===== Passport =====
     PASSPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 여권입니다."),

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.stream.Collectors;
 
@@ -25,7 +26,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(code, e.getMessage()));
     }
 
-    /** @Valid 검증 실패 */
+    /** validation(@Valid) 검증 실패 */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
         String detail = e.getBindingResult().getFieldErrors().stream()
@@ -53,6 +54,33 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.HANDLE_ACCESS_DENIED.getStatus())
                 .body(ApiResponse.error(ErrorCode.HANDLE_ACCESS_DENIED));
+    }
+
+    /** DB 제약조건 위반(유니크 등) */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        String message = String.valueOf(e.getMostSpecificCause().getMessage());
+        log.warn("[DataIntegrityViolation] {}", message);
+
+        String lower = message == null ? "" : message.toLowerCase();
+
+        // 1) 제약조건명으로 판별 (Postgres: duplicate key value violates unique constraint "uk_users_nickname")
+        if (lower.contains("uk_users_nickname")) {
+            return ResponseEntity
+                    .status(ErrorCode.DUPLICATE_NICKNAME.getStatus())
+                    .body(ApiResponse.error(ErrorCode.DUPLICATE_NICKNAME));
+        }
+
+        // 2) fallback: 환경에 따라 constraint명이 안 보일 수 있어 컬럼명 기반으로 한 번 더 매핑
+        if (lower.contains("nickname")) {
+            return ResponseEntity
+                    .status(ErrorCode.DUPLICATE_NICKNAME.getStatus())
+                    .body(ApiResponse.error(ErrorCode.DUPLICATE_NICKNAME));
+        }
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE));
     }
 
     /** 그 외 모든 예외 (최후의 보루) */

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.kauniv.lightrip.global.common.exception;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.kauniv.lightrip.global.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 
 import java.util.stream.Collectors;
 
@@ -76,6 +78,39 @@ public class GlobalExceptionHandler {
             return ResponseEntity
                     .status(ErrorCode.DUPLICATE_NICKNAME.getStatus())
                     .body(ApiResponse.error(ErrorCode.DUPLICATE_NICKNAME));
+        }
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE));
+    }
+
+    /** 요청 바디 파싱 실패(JSON enum 변환 실패 등) */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("[HttpMessageNotReadable] {}", e.getMessage());
+
+        Throwable cause = e.getCause();
+        if (cause instanceof InvalidFormatException ife) {
+            Class<?> targetType = ife.getTargetType();
+
+            if (targetType != null && targetType.isEnum()) {
+                String fieldName = ife.getPath() != null && !ife.getPath().isEmpty()
+                        ? ife.getPath().getFirst().getFieldName()
+                        : "";
+
+                String allowedValues = java.util.Arrays.stream(targetType.getEnumConstants())
+                        .map(Object::toString)
+                        .sorted()
+                        .collect(java.util.stream.Collectors.joining(", "));
+
+                String prettyField = (fieldName == null || fieldName.isBlank()) ? "요청 값" : fieldName;
+                String detail = String.format("%s은(는) %s 중 하나여야 합니다.", prettyField, allowedValues);
+
+                return ResponseEntity
+                        .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                        .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, detail));
+            }
         }
 
         return ResponseEntity

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.kauniv.lightrip.global.oauth.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -35,6 +36,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
                                 "/actuator/**"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/{userId}").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
@@ -50,5 +52,4 @@ public class SecurityConfig {
 
         return http.build();
     }
-
 }

--- a/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
@@ -6,6 +6,7 @@ import com.kauniv.lightrip.global.jwt.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -39,7 +41,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .orElseThrow(() -> new RuntimeException("Auth를 찾을 수 없습니다."));
         auth.updateRefreshToken(refreshToken);
 
-        System.out.println("===== ACCESS TOKEN: " + accessToken + " =====");
+        log.debug("ACCESS TOKEN: {}", accessToken);
 
         boolean isNewUser = oAuth2User.isNewUser();
 

--- a/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
@@ -39,6 +39,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .orElseThrow(() -> new RuntimeException("Auth를 찾을 수 없습니다."));
         auth.updateRefreshToken(refreshToken);
 
+        System.out.println("===== ACCESS TOKEN: " + accessToken + " =====");
+
         boolean isNewUser = oAuth2User.isNewUser();
 
         String deepLink = String.format(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,9 @@ sentry.send-default-pii=true
 spring.main.allow-circular-references=true
 server.forward-headers-strategy=native
 
+# token
+logging.level.com.kauniv.lightrip=${LOGGING_LEVEL:INFO}
+
 # API ?? (Swagger)
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #40 

## 📝 작업 내용

- [x] User 엔티티에 location, bio, friend_code 필드 추가
- [x] 내 프로필 조회 API 구현 (GET /api/v1/users/me)
- [x] 내 프로필 편집 API 구현 (PUT /api/v1/users/me)
- [x] 공개 프로필 조회 API 구현 (GET /api/v1/users/{userId})
- [x] 여권 수, 친구 수, 좋아요 수, 스크랩 수 집계 응답 추가
- [x] MyProfileResponse Stats 내부 클래스로 집계 데이터 분리
- [x] SecurityConfig 공개 프로필 permitAll 설정 추가
- [x] ErrorCode DUPLICATE_NICKNAME 추가

✅ PR 체크리스트
 - [x] PR 제목은 커밋 컨벤션을 따랐습니다.
 - [x] 관련 이슈를 연결했습니다.
 - [x] 변경 사항에 대한 테스트를 진행했습니다.

