### PR TITLE
FEAT: 지도 불빛 좌표 조회 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -22,6 +22,7 @@ import com.kauniv.lightrip.global.enums.District;
 import com.kauniv.lightrip.domain.passport.dto.response.FeedPassportResponse;
 import com.kauniv.lightrip.global.common.response.FeedCursorResponse;
 import java.math.BigDecimal;
+import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
 
 
 @Tag(name = "Passport", description = "여권 API")
@@ -154,6 +155,39 @@ public class PassportController {
         return ApiResponse.success(
                 passportService.getFeed(userId, category, district, latitude, longitude,
                         radius, cursor, cursorScore, size)
+        );
+    }
+
+    @Operation(summary = "내 불빛 조회",
+            description = "지도 화면에 표시할 본인 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
+                    "모든 visibility 노출.")
+    @GetMapping("/api/v1/users/me/lights")
+    public ApiResponse<List<LightResponse>> getMyLights(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
+            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
+            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng
+    ) {
+        return ApiResponse.success(
+                passportService.getMyLights(userId, minLat, maxLat, minLng, maxLng)
+        );
+    }
+
+    @Operation(summary = "특정 사용자 불빛 조회",
+            description = "지정된 사용자가 작성한 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
+                    "PUBLIC 노출 + 친구 관계인 경우 FRIENDS_ONLY 포함.")
+    @GetMapping("/api/v1/users/{userId}/lights")
+    public ApiResponse<List<LightResponse>> getUserLights(
+            @AuthenticationPrincipal Long viewerId,
+            @Parameter(description = "조회 대상 사용자 ID") @PathVariable Long userId,
+            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
+            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
+            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng
+    ) {
+        return ApiResponse.success(
+                passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng)
         );
     }
 

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/LightResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/LightResponse.java
@@ -1,0 +1,62 @@
+package com.kauniv.lightrip.domain.passport.dto.response;
+
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.global.enums.Category;
+import com.kauniv.lightrip.global.enums.District;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Schema(description = "지도 불빛 좌표 응답")
+public record LightResponse(
+
+        @Schema(description = "여권 ID")
+        Long passportId,
+
+        @Schema(description = "위도")
+        BigDecimal latitude,
+
+        @Schema(description = "경도")
+        BigDecimal longitude,
+
+        @Schema(description = "카테고리")
+        Category category,
+
+        @Schema(description = "지역 카테고리")
+        District districtCategory,
+
+        @Schema(description = "위치명")
+        String spaceName,
+
+        @Schema(description = "대표 이미지 URL (썸네일)")
+        String thumbnailUrl,
+
+        @Schema(description = "방문 날짜")
+        LocalDate visitedAt,
+
+        @Schema(description = "좋아요 수")
+        Long likeCount,
+
+        @Schema(description = "스크랩 수")
+        Long scrapCount
+) {
+    public static LightResponse from(Passport p) {
+        String thumbnail = p.getImages().isEmpty()
+                ? null
+                : p.getImages().get(0).getImageUrl();
+
+        return new LightResponse(
+                p.getId(),
+                p.getLatitude(),
+                p.getLongitude(),
+                p.getCategory(),
+                p.getDistrictCategory(),
+                p.getSpaceName(),
+                thumbnail,
+                p.getVisitedAt(),
+                p.getLikeCount(),
+                p.getScrapCount()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -11,6 +11,7 @@ import com.kauniv.lightrip.global.enums.Category;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
+import com.kauniv.lightrip.global.enums.Visibility;
 
 
 public interface PassportRepository extends JpaRepository<Passport, Long> {
@@ -119,4 +120,20 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
         WHERE p.id IN :ids
         """)
     List<Passport> findAllByIdsForFeed(List<Long> ids);
+
+    // ========== 지도 불빛 조회 (Bounding Box + visibility 필터) ==========
+    @Query("""
+        SELECT DISTINCT p FROM Passport p
+        LEFT JOIN FETCH p.images
+        WHERE p.user.id = :targetUserId
+          AND p.latitude BETWEEN :minLat AND :maxLat
+          AND p.longitude BETWEEN :minLng AND :maxLng
+          AND p.visibility IN :visibilities
+        """)
+    List<Passport> findLightsInBounds(
+            Long targetUserId,
+            BigDecimal minLat, BigDecimal maxLat,
+            BigDecimal minLng, BigDecimal maxLng,
+            List<Visibility> visibilities
+    );
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -39,7 +39,8 @@ import java.math.RoundingMode;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-
+import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
+import com.kauniv.lightrip.global.enums.Visibility;
 
 @Service
 @RequiredArgsConstructor
@@ -403,6 +404,61 @@ public class PassportService {
         return BigDecimal.valueOf(distance).setScale(2, RoundingMode.HALF_UP);
     }
 
+    // ========== 내 불빛 조회 ==========
+    public List<LightResponse> getMyLights(Long userId,
+                                           BigDecimal minLat, BigDecimal maxLat,
+                                           BigDecimal minLng, BigDecimal maxLng) {
+        validateBoundingBox(minLat, maxLat, minLng, maxLng);
 
+        // 본인은 모든 visibility 노출
+        List<Visibility> allowed = List.of(
+                Visibility.PUBLIC,
+                Visibility.PRIVATE,
+                Visibility.FRIENDS_ONLY
+        );
+
+        return passportRepository.findLightsInBounds(
+                        userId, minLat, maxLat, minLng, maxLng, allowed)
+                .stream()
+                .map(LightResponse::from)
+                .toList();
+    }
+
+    // ========== 특정 사용자 불빛 조회 ==========
+    public List<LightResponse> getUserLights(Long viewerId, Long targetUserId,
+                                             BigDecimal minLat, BigDecimal maxLat,
+                                             BigDecimal minLng, BigDecimal maxLng) {
+        validateBoundingBox(minLat, maxLat, minLng, maxLng);
+
+        // 본인 조회면 me 메서드로 위임
+        if (viewerId.equals(targetUserId)) {
+            return getMyLights(viewerId, minLat, maxLat, minLng, maxLng);
+        }
+
+        // 대상 사용자 존재 검증
+        if (!userRepository.existsById(targetUserId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        // 친구 여부에 따라 visibility 필터링
+        boolean isFriend = friendRepository.isFriend(viewerId, targetUserId);
+        List<Visibility> allowed = isFriend
+                ? List.of(Visibility.PUBLIC, Visibility.FRIENDS_ONLY)
+                : List.of(Visibility.PUBLIC);
+
+        return passportRepository.findLightsInBounds(
+                        targetUserId, minLat, maxLat, minLng, maxLng, allowed)
+                .stream()
+                .map(LightResponse::from)
+                .toList();
+    }
+
+    // ========== Bounding Box 검증 ==========
+    private void validateBoundingBox(BigDecimal minLat, BigDecimal maxLat,
+                                     BigDecimal minLng, BigDecimal maxLng) {
+        if (minLat.compareTo(maxLat) > 0 || minLng.compareTo(maxLng) > 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #45 

## 📝 작업 내용

지도 화면에서 사용자 여권을 별(불빛) 형태로 표시하기 위한 좌표 조회 API를 구현했습니다.
Bounding Box 기반 영역 필터로 데이터 양을 효율적으로 제한합니다.

- `LightResponse` DTO 작성 (좌표 + 카테고리 + 썸네일 + 부가 정보)
- `PassportRepository`에 Bounding Box 조회 메서드 추가 (fetch join, visibility 리스트 필터)
- `PassportService.getMyLights()`, `getUserLights()` 메서드 추가
- `PassportController`에 `/api/v1/users/me/lights`, `/api/v1/users/{userId}/lights` 엔드포인트 추가
- Visibility 기반 권한 분기 (본인 전체 / 친구 PUBLIC + FRIENDS_ONLY / 비친구 PUBLIC)
- Bounding Box 파라미터 검증 로직 추가

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.