### PR TITLE
FEAT: 친구 여권 조회 API 및 여권 공개 범위 변경 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -2,18 +2,22 @@ package com.kauniv.lightrip.domain.friend.controller;
 
 import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
+import com.kauniv.lightrip.domain.friend.dto.response.FriendPassportResponse;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
 import com.kauniv.lightrip.domain.friend.service.FriendService;
 import com.kauniv.lightrip.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
@@ -39,7 +43,7 @@ public class FriendController {
     @PatchMapping("/{friendId}")
     public ResponseEntity<?> handleRequest(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long friendId,
+            @Parameter(description = "Friend 테이블의 PK (friendshipId)") @PathVariable Long friendId,
             @Valid @RequestBody FriendStatusUpdateDto dto) {
 
         FriendResponseDto response = friendService.handleRequest(userId, friendId, dto);
@@ -50,17 +54,17 @@ public class FriendController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @Operation(summary = "친구 삭제", description = "친구 관계를 삭제합니다. 양쪽 당사자 모두 삭제 가능합니다.")
+    @Operation(summary = "친구 삭제", description = "친구 관계를 삭제합니다. 요청자/수신자 양쪽 모두 삭제 가능합니다.")
     @DeleteMapping("/{friendId}")
     public ApiResponse<Void> deleteFriend(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long friendId) {
+            @Parameter(description = "Friend 테이블의 PK (friendshipId)") @PathVariable Long friendId) {
 
         friendService.deleteFriend(userId, friendId);
         return ApiResponse.success("친구 관계가 삭제되었습니다.", null);
     }
 
-    @Operation(summary = "내 친구 목록 조회", description = "수락된 친구 목록을 조회합니다.")
+    @Operation(summary = "내 친구 목록 조회", description = "수락된 친구 목록을 전체 조회합니다.")
     @GetMapping
     public ApiResponse<List<FriendResponseDto>> getFriends(
             @AuthenticationPrincipal Long userId) {
@@ -69,7 +73,7 @@ public class FriendController {
         return ApiResponse.success(response);
     }
 
-    @Operation(summary = "받은 친구 요청 조회", description = "아직 수락하지 않은 친구 요청 목록을 조회합니다.")
+    @Operation(summary = "받은 친구 요청 조회", description = "아직 수락하지 않은 PENDING 상태의 친구 요청 목록을 조회합니다.")
     @GetMapping("/pending")
     public ApiResponse<List<FriendResponseDto>> getPendingRequests(
             @AuthenticationPrincipal Long userId) {
@@ -81,9 +85,21 @@ public class FriendController {
     @Operation(summary = "친구 코드로 유저 검색", description = "친구 코드로 유저를 검색합니다. 친구 요청 전 상대방 확인용입니다.")
     @GetMapping("/search")
     public ApiResponse<FriendResponseDto> searchByFriendCode(
-            @RequestParam String code) {
+            @Parameter(description = "검색할 친구 코드 (8자리 대문자)") @RequestParam String code) {
 
         FriendResponseDto response = friendService.searchByFriendCode(code);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(summary = "친구 여권 목록 조회", description = "친구의 공개(PUBLIC) 여권 목록을 조회합니다. ACCEPTED 상태의 친구만 조회 가능하며, PRIVATE 여권은 제외됩니다.")
+    @GetMapping("/{friendId}/passports")
+    public ApiResponse<List<FriendPassportResponse>> getFriendPassports(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "조회할 친구의 userId") @PathVariable Long friendId,
+            @PageableDefault(size = 20, sort = "visitedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        List<FriendPassportResponse> response =
+                friendService.getFriendPassports(userId, friendId, pageable);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendPassportResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendPassportResponse.java
@@ -1,0 +1,40 @@
+package com.kauniv.lightrip.domain.friend.dto.response;
+
+import com.kauniv.lightrip.domain.passport.entity.Passport;
+import com.kauniv.lightrip.global.enums.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class FriendPassportResponse {
+
+    private Long passportId;
+    private String spaceName;
+    private String address;
+    private Category category;
+    private LocalDate visitedAt;
+    private String content;
+    private List<String> imageUrls;
+    private Long likeCount;
+    private Long scrapCount;
+
+    public static FriendPassportResponse from(Passport passport) {
+        return FriendPassportResponse.builder()
+                .passportId(passport.getId())
+                .spaceName(passport.getSpaceName())
+                .address(passport.getAddress())
+                .category(passport.getCategory())
+                .visitedAt(passport.getVisitedAt())
+                .content(passport.getContent())
+                .imageUrls(passport.getImages().stream()
+                        .map(img -> img.getImageUrl())
+                        .toList())
+                .likeCount(passport.getLikeCount())
+                .scrapCount(passport.getScrapCount())
+                .build();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -3,14 +3,17 @@ package com.kauniv.lightrip.domain.friend.service;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendAction;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
 import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
+import com.kauniv.lightrip.domain.friend.dto.response.FriendPassportResponse;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
 import com.kauniv.lightrip.domain.friend.entity.Friend;
 import com.kauniv.lightrip.domain.friend.repository.FriendRepository;
+import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +26,7 @@ public class FriendService {
 
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
+    private final PassportRepository passportRepository;
 
     @Transactional
     public FriendResponseDto sendRequest(Long requesterId, FriendRequestDto dto) {
@@ -115,5 +119,24 @@ public class FriendService {
                 null,
                 null
         );
+    }
+
+    // 친구 여권 조회 — ACCEPTED 친구 관계 확인 후 PUBLIC 여권만 반환
+    public List<FriendPassportResponse> getFriendPassports(Long currentUserId,
+                                                           Long friendId,
+                                                           Pageable pageable) {
+        // 친구 관계 확인: isFriend()가 ACCEPTED 양방향 체크를 이미 수행
+        if (!friendRepository.isFriend(currentUserId, friendId)) {
+            throw new BusinessException(ErrorCode.FRIEND_NOT_MEMBER);
+        }
+
+        // 대상 유저 존재 확인
+        userRepository.findById(friendId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return passportRepository.findPublicPassportsByUserId(friendId, pageable)
+                .stream()
+                .map(FriendPassportResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -2,6 +2,7 @@ package com.kauniv.lightrip.domain.passport.controller;
 
 import com.kauniv.lightrip.domain.passport.dto.request.PassportCreateRequest;
 import com.kauniv.lightrip.domain.passport.dto.request.PassportUpdateRequest;
+import com.kauniv.lightrip.domain.passport.dto.request.PassportVisibilityRequest;
 import com.kauniv.lightrip.domain.passport.dto.response.PassportResponse;
 import com.kauniv.lightrip.domain.passport.dto.response.PassportStatsResponse;
 import com.kauniv.lightrip.domain.passport.service.PassportService;
@@ -24,7 +25,6 @@ import com.kauniv.lightrip.global.common.response.FeedCursorResponse;
 import java.math.BigDecimal;
 import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
 
-
 @Tag(name = "Passport", description = "여권 API")
 @RestController
 @RequestMapping("/api/v1/passports")
@@ -34,7 +34,7 @@ public class PassportController {
     private final PassportService passportService;
 
     @Operation(summary = "여권 등록",
-            description = "방문 기록을 여권으로 등록합니다. 이미지 1~5장 필수.")
+            description = "방문 기록을 여권으로 등록합니다. 이미지 1~5장 필수. visibility 미입력 시 PUBLIC으로 저장됩니다.")
     @PostMapping
     public ApiResponse<PassportResponse> create(
             @AuthenticationPrincipal Long userId,
@@ -52,6 +52,17 @@ public class PassportController {
             @Valid @RequestBody PassportUpdateRequest request
     ) {
         return ApiResponse.success("여권이 수정되었습니다.", passportService.update(userId, passportId, request));
+    }
+
+    @Operation(summary = "여권 공개 범위 변경",
+            description = "여권의 공개 범위만 단독으로 변경합니다. 작성자 본인만 변경 가능합니다. (PUBLIC / FRIENDS_ONLY / PRIVATE)")
+    @PatchMapping("/{passportId}/visibility")
+    public ApiResponse<PassportResponse> updateVisibility(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "여권 ID") @PathVariable Long passportId,
+            @Valid @RequestBody PassportVisibilityRequest request
+    ) {
+        return ApiResponse.success("공개 범위가 변경되었습니다.", passportService.updateVisibility(userId, passportId, request));
     }
 
     @Operation(summary = "여권 삭제",
@@ -92,8 +103,6 @@ public class PassportController {
                 **필터링**
                 - `category`: 카테고리별 필터 (CAFE, RESTAURANT, BAR, TOURIST, NATURE, CULTURE, ACTIVITY, ACCOMMODATION, SHOPPING, ETC)
                 - `districtCategory`: 지역별 필터 (MAPO, GANGNAM, YONGSAN 등)
-                - 필터는 복수 적용 가능합니다. (예: category=CAFE & districtCategory=MAPO → 마포구 카페만)
-                - 필터를 넣지 않으면 전체 여권이 조회됩니다.
                 
                 **페이징 (커서 기반 무한스크롤)**
                 - 첫 요청: `cursor` 파라미터 없이 호출
@@ -103,22 +112,13 @@ public class PassportController {
     @GetMapping("/me")
     public ApiResponse<CursorResponse<PassportListResponse>> getMyPassports(
             @AuthenticationPrincipal Long userId,
-
-            @Parameter(description = "카테고리 필터 (선택). 예: CAFE, RESTAURANT, BAR, TOURIST, NATURE, CULTURE, ACTIVITY, ACCOMMODATION, SHOPPING, ETC")
-            @RequestParam(required = false) Category category,
-
-            @Parameter(description = "지역 필터 (선택). 예: MAPO, GANGNAM, YONGSAN, JONGNO 등")
-            @RequestParam(required = false) District districtCategory,
-
-            @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략")
-            @RequestParam(required = false) Long cursor,
-
-            @Parameter(description = "한 페이지에 가져올 여권 수 (기본값: 10, 최대: 50)")
-            @RequestParam(defaultValue = "10") int size
+            @Parameter(description = "카테고리 필터 (선택)") @RequestParam(required = false) Category category,
+            @Parameter(description = "지역 필터 (선택)") @RequestParam(required = false) District districtCategory,
+            @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 페이지에 가져올 여권 수 (기본값: 10, 최대: 50)") @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.success(passportService.getMyPassports(userId, category, districtCategory, cursor, size));
     }
-
 
     @Operation(summary = "내 여권 통계 조회",
             description = "내가 작성한 여권 수, 좋아요 누른 수, 스크랩한 수를 조회합니다.")
@@ -130,27 +130,18 @@ public class PassportController {
     }
 
     @Operation(summary = "릴스형 여권 피드 조회",
-            description = "다른 사용자의 PUBLIC 여권을 인기순으로 조회합니다. " +
-                    "카테고리/지역/위치 필터 지원, 커서 기반 무한스크롤.")
+            description = "다른 사용자의 PUBLIC 여권을 인기순으로 조회합니다. 카테고리/지역/위치 필터 지원, 커서 기반 무한스크롤.")
     @GetMapping("/api/v1/feed")
     public ApiResponse<FeedCursorResponse<FeedPassportResponse>> getFeed(
             @AuthenticationPrincipal Long userId,
-            @Parameter(description = "카테고리 필터")
-            @RequestParam(required = false) Category category,
-            @Parameter(description = "지역 필터")
-            @RequestParam(required = false) District district,
-            @Parameter(description = "사용자 위도")
-            @RequestParam(required = false) BigDecimal latitude,
-            @Parameter(description = "사용자 경도")
-            @RequestParam(required = false) BigDecimal longitude,
-            @Parameter(description = "반경(km), 기본 5")
-            @RequestParam(defaultValue = "5") int radius,
-            @Parameter(description = "커서 (마지막 여권 ID)")
-            @RequestParam(required = false) Long cursor,
-            @Parameter(description = "커서 점수 (마지막 인기 점수)")
-            @RequestParam(required = false) Long cursorScore,
-            @Parameter(description = "조회 개수, 기본 10")
-            @RequestParam(defaultValue = "10") int size
+            @Parameter(description = "카테고리 필터") @RequestParam(required = false) Category category,
+            @Parameter(description = "지역 필터") @RequestParam(required = false) District district,
+            @Parameter(description = "사용자 위도") @RequestParam(required = false) BigDecimal latitude,
+            @Parameter(description = "사용자 경도") @RequestParam(required = false) BigDecimal longitude,
+            @Parameter(description = "반경(km), 기본 5") @RequestParam(defaultValue = "5") int radius,
+            @Parameter(description = "커서 (마지막 여권 ID)") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "커서 점수 (마지막 인기 점수)") @RequestParam(required = false) Long cursorScore,
+            @Parameter(description = "조회 개수, 기본 10") @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.success(
                 passportService.getFeed(userId, category, district, latitude, longitude,

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportVisibilityRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportVisibilityRequest.java
@@ -1,0 +1,13 @@
+package com.kauniv.lightrip.domain.passport.dto.request;
+
+import com.kauniv.lightrip.global.enums.Visibility;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "여권 공개 범위 변경 요청")
+public record PassportVisibilityRequest(
+
+        @Schema(description = "공개 범위 (PUBLIC / FRIENDS_ONLY / PRIVATE)", example = "PRIVATE")
+        @NotNull(message = "공개 범위는 필수입니다.")
+        Visibility visibility
+) {}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
@@ -139,6 +139,10 @@ public class Passport {
         }
     }
 
+    public void updateVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
+
     /**
      * 해당 사용자가 이 여권의 작성자인지 확인
      */

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -1,5 +1,5 @@
-// domain/passport/repository/PassportRepository.java
 package com.kauniv.lightrip.domain.passport.repository;
+
 import com.kauniv.lightrip.global.enums.District;
 import java.util.Optional;
 import com.kauniv.lightrip.domain.passport.entity.Passport;
@@ -13,24 +13,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import com.kauniv.lightrip.global.enums.Visibility;
 
-
 public interface PassportRepository extends JpaRepository<Passport, Long> {
 
-    // 중복 등록 방지 (uk_passport_user_location_date)
     boolean existsByUser_IdAndLatitudeAndLongitudeAndVisitedAt(
             Long userId, BigDecimal latitude, BigDecimal longitude, LocalDate visitedAt
     );
 
-    // 해당 구에 사용자 여권이 있는지 확인
     boolean existsByUser_IdAndDistrictCategory(Long userId, District districtCategory);
 
-    // 해당 구의 가장 최근 여권 조회 (삭제 시 대표 이미지 교체용)
     Optional<Passport> findFirstByUser_IdAndDistrictCategoryOrderByCreatedAtDesc(
             Long userId, District districtCategory
     );
 
-
-    // 사용자의 지역별 여권 수 조회
     @Query("""
         SELECT p.districtCategory, COUNT(p)
         FROM Passport p
@@ -40,7 +34,6 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
         """)
     List<Object[]> countByUserIdGroupByDistrict(Long userId);
 
-    // 장소별 여권 목록 (필터 + 커서, 첫 요청)
     @Query("""
         SELECT p FROM Passport p
         LEFT JOIN FETCH p.images
@@ -54,7 +47,6 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
                                         District districtCategory,
                                         Pageable pageable);
 
-    // 장소별 여권 목록 (필터 + 커서, 다음 페이지)
     @Query("""
         SELECT p FROM Passport p
         LEFT JOIN FETCH p.images
@@ -69,9 +61,9 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
                                               Category category,
                                               District districtCategory,
                                               Pageable pageable);
+
     long countByUser_Id(Long userId);
 
-    // ========== 피드 조회: 인기순 + 필터 + 커서 (정렬된 ID 리스트) ==========
     @Query(value = """
         SELECT p.passport_id
         FROM passport p
@@ -112,7 +104,6 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
             @Param("limit") int limit
     );
 
-    // ========== ID 리스트로 여권 + 이미지 + 작성자 fetch ==========
     @Query("""
         SELECT DISTINCT p FROM Passport p
         LEFT JOIN FETCH p.images
@@ -136,4 +127,15 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
             BigDecimal minLng, BigDecimal maxLng,
             List<Visibility> visibilities
     );
+
+    // 친구 여권 조회: visibility = PUBLIC인 여권만 반환
+    @Query("""
+        SELECT p FROM Passport p
+        LEFT JOIN FETCH p.images
+        WHERE p.user.id = :userId
+          AND p.visibility = com.kauniv.lightrip.global.enums.Visibility.PUBLIC
+        ORDER BY p.visitedAt DESC, p.id DESC
+        """)
+    List<Passport> findPublicPassportsByUserId(@Param("userId") Long userId,
+                                               Pageable pageable);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -3,6 +3,7 @@ package com.kauniv.lightrip.domain.passport.service;
 import com.kauniv.lightrip.domain.friend.repository.FriendRepository;
 import com.kauniv.lightrip.domain.passport.dto.request.PassportCreateRequest;
 import com.kauniv.lightrip.domain.passport.dto.request.PassportUpdateRequest;
+import com.kauniv.lightrip.domain.passport.dto.request.PassportVisibilityRequest;
 import com.kauniv.lightrip.domain.passport.dto.response.PassportResponse;
 import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
 import com.kauniv.lightrip.domain.passport.entity.Passport;
@@ -41,6 +42,7 @@ import java.util.Objects;
 import java.util.Set;
 import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
 import com.kauniv.lightrip.global.enums.Visibility;
+
 
 @Service
 @RequiredArgsConstructor
@@ -95,9 +97,8 @@ public class PassportService {
 
         passportRepository.save(passport);
         passport.replaceImages(req.imageUrls());
-        passportRepository.flush(); // 이미지 ID 생성을 위해 flush
+        passportRepository.flush();
 
-        // DistrictCover 자동 생성 (해당 구에 첫 등록이면)
         createDistrictCoverIfFirst(user, passport);
 
         return PassportResponse.from(passport);
@@ -128,6 +129,23 @@ public class PassportService {
         );
 
         passport.replaceImages(req.imageUrls());
+
+        return PassportResponse.from(passport);
+    }
+
+    // ========== 공개 범위 단독 변경 ==========
+    @Transactional
+    public PassportResponse updateVisibility(Long userId, Long passportId,
+                                             PassportVisibilityRequest req) {
+        Passport passport = passportRepository.findById(passportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
+
+        // 본인 여권만 공개 범위 변경 가능 (팀 여권도 작성자만)
+        if (!passport.isOwnedBy(userId)) {
+            throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
+        }
+
+        passport.updateVisibility(req.visibility());
 
         return PassportResponse.from(passport);
     }
@@ -180,16 +198,13 @@ public class PassportService {
     private void cleanupDistrictCover(Long userId, District district) {
         districtCoverRepository.findByUser_IdAndDistrictCategory(userId, district)
                 .ifPresent(cover -> {
-                    // 해당 구에 다른 여권이 남아있는지 확인
                     passportRepository.findFirstByUser_IdAndDistrictCategoryOrderByCreatedAtDesc(userId, district)
                             .ifPresentOrElse(
-                                    // 남은 여권 있으면 → 그 여권의 첫 이미지로 교체
                                     latestPassport -> {
                                         if (!latestPassport.getImages().isEmpty()) {
                                             cover.changeCoverImage(latestPassport.getImages().get(0));
                                         }
                                     },
-                                    // 남은 여권 없으면 → DistrictCover 삭제
                                     () -> districtCoverRepository.delete(cover)
                             );
                 });
@@ -243,17 +258,14 @@ public class PassportService {
 
     // ========== 내 기록 지역 조회 ==========
     public List<DistrictResponse> getMyDistricts(Long userId) {
-        // 1. 지역별 여권 수 조회
         List<Object[]> counts = passportRepository.countByUserIdGroupByDistrict(userId);
 
-        // 2. 사용자의 DistrictCover 전체 조회 → Map으로 변환
         Map<District, String> coverMap = districtCoverRepository.findAllByUser_Id(userId).stream()
                 .collect(Collectors.toMap(
                         DistrictCover::getDistrictCategory,
                         cover -> cover.getPassportImage().getImageUrl()
                 ));
 
-        // 3. 합치기
         return counts.stream()
                 .map(row -> {
                     District district = (District) row[0];
@@ -263,7 +275,6 @@ public class PassportService {
                 })
                 .toList();
     }
-
 
     // ========== 내 여권 목록 조회 (장소별, 커서 기반) ==========
     public CursorResponse<PassportListResponse> getMyPassports(Long userId,
@@ -302,30 +313,17 @@ public class PassportService {
 
     // ========== 릴스형 여권 피드 조회 ==========
     public FeedCursorResponse<FeedPassportResponse> getFeed(
-            Long userId,
-            Category category,
-            District district,
-            BigDecimal latitude,
-            BigDecimal longitude,
-            int radius,
-            Long cursor,
-            Long cursorScore,
-            int size
-    ) {
-        // 1. 위치 파라미터 검증
+            Long userId, Category category, District district,
+            BigDecimal latitude, BigDecimal longitude,
+            int radius, Long cursor, Long cursorScore, int size) {
+
         validateLocation(latitude, longitude);
 
-        // 2. 후보 여권 ID 조회 (정렬된 상태)
         List<Long> candidateIds = passportRepository.findFeedPassportIds(
                 userId,
                 category != null ? category.name() : null,
                 district != null ? district.name() : null,
-                latitude,
-                longitude,
-                radius,
-                cursor,
-                cursorScore,
-                size + 1
+                latitude, longitude, radius, cursor, cursorScore, size + 1
         );
 
         if (candidateIds.isEmpty()) {
@@ -337,10 +335,8 @@ public class PassportService {
             candidateIds = candidateIds.subList(0, size);
         }
 
-        // 3. 여권 엔티티 fetch join (N+1 방지)
         List<Passport> passports = passportRepository.findAllByIdsForFeed(candidateIds);
 
-        // 4. 정렬 순서 복원 (IN 쿼리는 순서 보장 X)
         Map<Long, Passport> passportMap = passports.stream()
                 .collect(Collectors.toMap(Passport::getId, p -> p));
         List<Passport> ordered = candidateIds.stream()
@@ -348,7 +344,6 @@ public class PassportService {
                 .filter(Objects::nonNull)
                 .toList();
 
-        // 5. 좋아요/스크랩/친구 일괄 조회
         Set<Long> likedIds = new HashSet<>(likeRepository.findLikedPassportIds(userId, candidateIds));
         Set<Long> scrappedIds = new HashSet<>(scrapRepository.findScrappedPassportIds(userId, candidateIds));
 
@@ -358,7 +353,6 @@ public class PassportService {
                 .toList();
         Set<Long> friendIds = new HashSet<>(friendRepository.findFriendUserIdsAmong(userId, writerIds));
 
-        // 6. 응답 구성
         List<FeedPassportResponse> content = ordered.stream()
                 .map(p -> {
                     BigDecimal distance = (latitude != null && longitude != null)
@@ -368,7 +362,6 @@ public class PassportService {
                 })
                 .toList();
 
-        // 7. nextCursor 추출
         Long nextCursor = null;
         Long nextCursorScore = null;
         if (hasNext && !content.isEmpty()) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #46

## 📝 작업 내용

- [x] `PassportRepository`에 `findPublicPassportsByUserId()` 추가 (PUBLIC 여권만 조회)
- [x] `FriendRepository`에 `isFriend()` 활용한 친구 관계 검증 로직 적용
- [x] `FriendPassportResponse` DTO 신규 생성
- [x] `FriendService`에 `getFriendPassports()` 메서드 추가
- [x] `FriendController`에 `GET /api/v1/friends/{friendId}/passports` 엔드포인트 추가
- [x] `PassportVisibilityRequest` DTO 신규 생성
- [x] `PassportService`에 `updateVisibility()` 메서드 추가
- [x] `PassportController`에 `PATCH /api/v1/passports/{passportId}/visibility` 엔드포인트 추가
- [x] `Passport` 엔티티에 `updateVisibility()` 도메인 메서드 추가


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

