### PR TITLE
feat: 친구 지도 조회 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -1,10 +1,11 @@
 package com.kauniv.lightrip.domain.friend.controller;
 
-import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
-import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
+import com.kauniv.lightrip.domain.friend.dto.request.FriendRequest;
+import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdate;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendPassportResponse;
-import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
+import com.kauniv.lightrip.domain.friend.dto.response.FriendResponse;
 import com.kauniv.lightrip.domain.friend.service.FriendService;
+import com.kauniv.lightrip.domain.passport.dto.response.DistrictResponse;
 import com.kauniv.lightrip.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,11 +32,11 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 보내기", description = "친구 코드로 상대방에게 친구 요청을 보냅니다.")
     @PostMapping("/request")
-    public ResponseEntity<ApiResponse<FriendResponseDto>> sendRequest(
+    public ResponseEntity<ApiResponse<FriendResponse>> sendRequest(
             @AuthenticationPrincipal Long userId,
-            @Valid @RequestBody FriendRequestDto dto) {
+            @Valid @RequestBody FriendRequest dto) {
 
-        FriendResponseDto response = friendService.sendRequest(userId, dto);
+        FriendResponse response = friendService.sendRequest(userId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
@@ -44,9 +45,9 @@ public class FriendController {
     public ResponseEntity<?> handleRequest(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "Friend 테이블의 PK (friendshipId)") @PathVariable Long friendId,
-            @Valid @RequestBody FriendStatusUpdateDto dto) {
+            @Valid @RequestBody FriendStatusUpdate dto) {
 
-        FriendResponseDto response = friendService.handleRequest(userId, friendId, dto);
+        FriendResponse response = friendService.handleRequest(userId, friendId, dto);
 
         if (response == null) {
             return ResponseEntity.noContent().build();
@@ -66,28 +67,28 @@ public class FriendController {
 
     @Operation(summary = "내 친구 목록 조회", description = "수락된 친구 목록을 전체 조회합니다.")
     @GetMapping
-    public ApiResponse<List<FriendResponseDto>> getFriends(
+    public ApiResponse<List<FriendResponse>> getFriends(
             @AuthenticationPrincipal Long userId) {
 
-        List<FriendResponseDto> response = friendService.getFriends(userId);
+        List<FriendResponse> response = friendService.getFriends(userId);
         return ApiResponse.success(response);
     }
 
     @Operation(summary = "받은 친구 요청 조회", description = "아직 수락하지 않은 PENDING 상태의 친구 요청 목록을 조회합니다.")
     @GetMapping("/pending")
-    public ApiResponse<List<FriendResponseDto>> getPendingRequests(
+    public ApiResponse<List<FriendResponse>> getPendingRequests(
             @AuthenticationPrincipal Long userId) {
 
-        List<FriendResponseDto> response = friendService.getPendingRequests(userId);
+        List<FriendResponse> response = friendService.getPendingRequests(userId);
         return ApiResponse.success(response);
     }
 
     @Operation(summary = "친구 코드로 유저 검색", description = "친구 코드로 유저를 검색합니다. 친구 요청 전 상대방 확인용입니다.")
     @GetMapping("/search")
-    public ApiResponse<FriendResponseDto> searchByFriendCode(
+    public ApiResponse<FriendResponse> searchByFriendCode(
             @Parameter(description = "검색할 친구 코드 (8자리 대문자)") @RequestParam String code) {
 
-        FriendResponseDto response = friendService.searchByFriendCode(code);
+        FriendResponse response = friendService.searchByFriendCode(code);
         return ApiResponse.success(response);
     }
 
@@ -100,6 +101,16 @@ public class FriendController {
 
         List<FriendPassportResponse> response =
                 friendService.getFriendPassports(userId, friendId, pageable);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(summary = "친구 지도 조회", description = "친구의 공개(PUBLIC) 여권 기준으로 방문한 지역 목록을 조회합니다. ACCEPTED 상태의 친구만 조회 가능합니다.")
+    @GetMapping("/{friendId}/map")
+    public ApiResponse<List<DistrictResponse>> getFriendDistricts(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "조회할 친구의 userId") @PathVariable Long friendId) {
+
+        List<DistrictResponse> response = friendService.getFriendDistricts(userId, friendId);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendRequest.java
@@ -2,7 +2,7 @@ package com.kauniv.lightrip.domain.friend.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record FriendRequestDto(
+public record FriendRequest(
         @NotBlank(message = "친구 코드는 필수입니다.")
         String friendCode
 ) {}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendStatusUpdate.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/request/FriendStatusUpdate.java
@@ -3,7 +3,7 @@ package com.kauniv.lightrip.domain.friend.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record FriendStatusUpdateDto(
+public record FriendStatusUpdate(
         @Schema(description = "친구 요청 처리 액션", allowableValues = {"ACCEPT", "REJECT"}, example = "ACCEPT")
         @NotNull(message = "액션은 필수입니다.")
         FriendAction action

--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
@@ -5,7 +5,7 @@ import com.kauniv.lightrip.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 
-public record FriendResponseDto(
+public record FriendResponse(
         Long friendId,
         Long userId,
         String nickname,
@@ -14,8 +14,8 @@ public record FriendResponseDto(
         String status,
         LocalDateTime createdAt
 ) {
-    public static FriendResponseDto from(Friend friend, User target) {
-        return new FriendResponseDto(
+    public static FriendResponse from(Friend friend, User target) {
+        return new FriendResponse(
                 friend.getId(),
                 target.getId(),
                 target.getNickname(),

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -1,23 +1,29 @@
 package com.kauniv.lightrip.domain.friend.service;
 
 import com.kauniv.lightrip.domain.friend.dto.request.FriendAction;
-import com.kauniv.lightrip.domain.friend.dto.request.FriendRequestDto;
-import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdateDto;
+import com.kauniv.lightrip.domain.friend.dto.request.FriendRequest;
+import com.kauniv.lightrip.domain.friend.dto.request.FriendStatusUpdate;
 import com.kauniv.lightrip.domain.friend.dto.response.FriendPassportResponse;
-import com.kauniv.lightrip.domain.friend.dto.response.FriendResponseDto;
+import com.kauniv.lightrip.domain.friend.dto.response.FriendResponse;
 import com.kauniv.lightrip.domain.friend.entity.Friend;
 import com.kauniv.lightrip.domain.friend.repository.FriendRepository;
+import com.kauniv.lightrip.domain.passport.dto.response.DistrictResponse;
+import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
+import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
 import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import com.kauniv.lightrip.global.enums.District;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,9 +33,10 @@ public class FriendService {
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
     private final PassportRepository passportRepository;
+    private final DistrictCoverRepository districtCoverRepository;
 
     @Transactional
-    public FriendResponseDto sendRequest(Long requesterId, FriendRequestDto dto) {
+    public FriendResponse sendRequest(Long requesterId, FriendRequest dto) {
         User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -51,11 +58,11 @@ public class FriendService {
                 .build();
 
         friendRepository.save(friend);
-        return FriendResponseDto.from(friend, receiver);
+        return FriendResponse.from(friend, receiver);
     }
 
     @Transactional
-    public FriendResponseDto handleRequest(Long userId, Long friendId, FriendStatusUpdateDto dto) {
+    public FriendResponse handleRequest(Long userId, Long friendId, FriendStatusUpdate dto) {
         Friend friend = friendRepository.findById(friendId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FRIEND_NOT_FOUND));
 
@@ -65,7 +72,7 @@ public class FriendService {
 
         if (dto.action() == FriendAction.ACCEPT) {
             friend.accept();
-            return FriendResponseDto.from(friend, friend.getRequester());
+            return FriendResponse.from(friend, friend.getRequester());
         } else {
             friendRepository.delete(friend);
             return null;
@@ -85,7 +92,7 @@ public class FriendService {
         friendRepository.delete(friend);
     }
 
-    public List<FriendResponseDto> getFriends(Long userId) {
+    public List<FriendResponse> getFriends(Long userId) {
         List<Friend> friends = friendRepository.findAllFriends(userId);
 
         return friends.stream()
@@ -93,24 +100,24 @@ public class FriendService {
                     User target = friend.getRequester().getId().equals(userId)
                             ? friend.getReceiver()
                             : friend.getRequester();
-                    return FriendResponseDto.from(friend, target);
+                    return FriendResponse.from(friend, target);
                 })
                 .toList();
     }
 
-    public List<FriendResponseDto> getPendingRequests(Long userId) {
+    public List<FriendResponse> getPendingRequests(Long userId) {
         List<Friend> pendings = friendRepository.findPendingRequests(userId);
 
         return pendings.stream()
-                .map(friend -> FriendResponseDto.from(friend, friend.getRequester()))
+                .map(friend -> FriendResponse.from(friend, friend.getRequester()))
                 .toList();
     }
 
-    public FriendResponseDto searchByFriendCode(String friendCode) {
+    public FriendResponse searchByFriendCode(String friendCode) {
         User user = userRepository.findByFriendCode(friendCode)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        return new FriendResponseDto(
+        return new FriendResponse(
                 null,
                 user.getId(),
                 user.getNickname(),
@@ -125,18 +132,45 @@ public class FriendService {
     public List<FriendPassportResponse> getFriendPassports(Long currentUserId,
                                                            Long friendId,
                                                            Pageable pageable) {
-        // 친구 관계 확인: isFriend()가 ACCEPTED 양방향 체크를 이미 수행
         if (!friendRepository.isFriend(currentUserId, friendId)) {
             throw new BusinessException(ErrorCode.FRIEND_NOT_MEMBER);
         }
 
-        // 대상 유저 존재 확인
         userRepository.findById(friendId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         return passportRepository.findPublicPassportsByUserId(friendId, pageable)
                 .stream()
                 .map(FriendPassportResponse::from)
+                .toList();
+    }
+
+    // 친구 지도 조회 — PUBLIC 여권 기준 district 목록 반환
+    public List<DistrictResponse> getFriendDistricts(Long currentUserId, Long friendId) {
+        if (!friendRepository.isFriend(currentUserId, friendId)) {
+            throw new BusinessException(ErrorCode.FRIEND_NOT_MEMBER);
+        }
+
+        userRepository.findById(friendId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // PUBLIC 여권 기준 district별 여권 수 조회
+        List<Object[]> counts = passportRepository.countPublicByUserIdGroupByDistrict(friendId);
+
+        // 친구의 DistrictCover 조회 → 썸네일 매핑
+        Map<District, String> coverMap = districtCoverRepository.findAllByUser_Id(friendId).stream()
+                .collect(Collectors.toMap(
+                        DistrictCover::getDistrictCategory,
+                        cover -> cover.getPassportImage().getImageUrl()
+                ));
+
+        return counts.stream()
+                .map(row -> {
+                    District district = (District) row[0];
+                    Long count = (Long) row[1];
+                    String thumbnailUrl = coverMap.get(district);
+                    return DistrictResponse.of(district, count, thumbnailUrl);
+                })
                 .toList();
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -34,6 +34,17 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
         """)
     List<Object[]> countByUserIdGroupByDistrict(Long userId);
 
+    // 친구 지도 조회: PUBLIC 여권 기준 district별 여권 수
+    @Query("""
+        SELECT p.districtCategory, COUNT(p)
+        FROM Passport p
+        WHERE p.user.id = :userId
+          AND p.visibility = com.kauniv.lightrip.global.enums.Visibility.PUBLIC
+        GROUP BY p.districtCategory
+        ORDER BY COUNT(p) DESC
+        """)
+    List<Object[]> countPublicByUserIdGroupByDistrict(@Param("userId") Long userId);
+
     @Query("""
         SELECT p FROM Passport p
         LEFT JOIN FETCH p.images
@@ -112,7 +123,6 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
         """)
     List<Passport> findAllByIdsForFeed(List<Long> ids);
 
-    // ========== 지도 불빛 조회 (Bounding Box + visibility 필터) ==========
     @Query("""
         SELECT DISTINCT p FROM Passport p
         LEFT JOIN FETCH p.images
@@ -128,7 +138,6 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
             List<Visibility> visibilities
     );
 
-    // 친구 여권 조회: visibility = PUBLIC인 여권만 반환
     @Query("""
         SELECT p FROM Passport p
         LEFT JOIN FETCH p.images


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #50

## 📝 작업 내용

- [x] `PassportRepository`에 `countPublicByUserIdGroupByDistrict()` 추가 — PUBLIC 여권 기준 district별 여권 수 집계
- [x] `FriendService`에 `getFriendDistricts()` 추가 — 친구 관계 검증 후 PUBLIC 여권 기준 방문 지역 목록 반환
- [x] `FriendService`에 `DistrictCoverRepository` 주입 — district별 썸네일 이미지 매핑
- [x] `FriendController`에 `GET /api/v1/friends/{friendId}/map` 엔드포인트 추가

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.
