### PR TITLE
FEAT: 추천 친구 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -113,4 +113,13 @@ public class FriendController {
         List<DistrictResponse> response = friendService.getFriendDistricts(userId, friendId);
         return ApiResponse.success(response);
     }
+
+    @Operation(summary = "추천 친구 목록 조회", description = "내가 스크랩한 여권의 작성자 중 아직 친구가 아닌 유저를 최대 4명 랜덤으로 추천합니다.")
+    @GetMapping("/recommendations")
+    public ApiResponse<List<FriendResponse>> getRecommendedFriends(
+            @AuthenticationPrincipal Long userId) {
+
+        List<FriendResponse> response = friendService.getRecommendedFriends(userId);
+        return ApiResponse.success(response);
+    }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -11,6 +11,7 @@ import com.kauniv.lightrip.domain.passport.dto.response.DistrictResponse;
 import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
 import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
 import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
+import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
@@ -21,8 +22,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,6 +37,7 @@ public class FriendService {
     private final UserRepository userRepository;
     private final PassportRepository passportRepository;
     private final DistrictCoverRepository districtCoverRepository;
+    private final ScrapRepository scrapRepository;
 
     @Transactional
     public FriendResponse sendRequest(Long requesterId, FriendRequest dto) {
@@ -154,10 +158,8 @@ public class FriendService {
         userRepository.findById(friendId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // PUBLIC 여권 기준 district별 여권 수 조회
         List<Object[]> counts = passportRepository.countPublicByUserIdGroupByDistrict(friendId);
 
-        // 친구의 DistrictCover 조회 → 썸네일 매핑
         Map<District, String> coverMap = districtCoverRepository.findAllByUser_Id(friendId).stream()
                 .collect(Collectors.toMap(
                         DistrictCover::getDistrictCategory,
@@ -171,6 +173,53 @@ public class FriendService {
                     String thumbnailUrl = coverMap.get(district);
                     return DistrictResponse.of(district, count, thumbnailUrl);
                 })
+                .toList();
+    }
+
+    // 추천 친구 조회 — 내가 스크랩한 여권 작성자 중 아직 친구가 아닌 유저 최대 4명 랜덤 반환
+    public List<FriendResponse> getRecommendedFriends(Long userId) {
+        // 1. 내가 스크랩한 여권의 작성자 ID 목록 (본인 제외)
+        List<Long> candidateIds = scrapRepository.findScrapedPassportOwnerIds(userId);
+
+        if (candidateIds.isEmpty()) {
+            return List.of();
+        }
+
+        // 2. 이미 친구이거나 요청 중인 유저 제외
+        Set<Long> existingFriendIds = friendRepository.findAllFriends(userId).stream()
+                .map(f -> f.getRequester().getId().equals(userId)
+                        ? f.getReceiver().getId()
+                        : f.getRequester().getId())
+                .collect(Collectors.toSet());
+
+        // PENDING 상태도 제외
+        Set<Long> pendingIds = friendRepository.findPendingRequests(userId).stream()
+                .map(f -> f.getRequester().getId())
+                .collect(Collectors.toSet());
+
+        List<Long> filteredIds = candidateIds.stream()
+                .filter(id -> !existingFriendIds.contains(id) && !pendingIds.contains(id))
+                .collect(Collectors.toList());
+
+        // 3. 랜덤 셔플 후 최대 4명 추출
+        Collections.shuffle(filteredIds);
+        List<Long> selectedIds = filteredIds.stream().limit(4).toList();
+
+        if (selectedIds.isEmpty()) {
+            return List.of();
+        }
+
+        // 4. User 정보 조회 후 응답 변환
+        return userRepository.findAllById(selectedIds).stream()
+                .map(user -> new FriendResponse(
+                        null,
+                        user.getId(),
+                        user.getNickname(),
+                        user.getProfileImg(),
+                        user.getFriendCode(),
+                        null,
+                        null
+                ))
                 .toList();
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/scrap/repository/ScrapRepository.java
@@ -46,4 +46,13 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
             """)
     List<Long> findScrappedPassportIds(@Param("userId") Long userId,
                                        @Param("passportIds") List<Long> passportIds);
+
+    // 내가 스크랩한 여권의 작성자 userId 목록 조회 (본인 제외, 중복 제거)
+    @Query("""
+    SELECT DISTINCT s.passport.user.id
+    FROM Scrap s
+    WHERE s.user.id = :userId
+      AND s.passport.user.id <> :userId
+    """)
+    List<Long> findScrapedPassportOwnerIds(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #54

## 📝 작업 내용

- [x] `ScrapRepository`에 `findScrapedPassportOwnerIds()` 추가 — 내가 스크랩한 여권의 작성자 userId 목록 조회 (본인 제외, 중복 제거)
- [x] `FriendService`에 `getRecommendedFriends()` 추가 — 스크랩 작성자 중 친구/PENDING 상태 제외 후 최대 4명 랜덤 추천
- [x] `FriendController`에 `GET /api/v1/friends/recommendations` 엔드포인트 추가

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

