### PR TITLE
FEAT: 전체 주간 랭킹 조회 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/LightripApplication.java
+++ b/src/main/java/com/kauniv/lightrip/LightripApplication.java
@@ -2,7 +2,9 @@ package com.kauniv.lightrip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class LightripApplication {
 

--- a/src/main/java/com/kauniv/lightrip/domain/ranking/controller/RankingController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/ranking/controller/RankingController.java
@@ -1,0 +1,39 @@
+package com.kauniv.lightrip.domain.ranking.controller;
+
+import com.kauniv.lightrip.domain.ranking.dto.response.TotalRankingResponse;
+import com.kauniv.lightrip.domain.ranking.service.RankingService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Ranking", description = "랭킹 API")
+@RestController
+@RequestMapping("/api/v1/rankings")
+@RequiredArgsConstructor
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    @Operation(
+            summary = "전체 주간 랭킹 조회",
+            description = """
+                    지난 1주일간 좋아요(×2)와 스크랩(×3)을 합산한 주간 랭킹을 조회합니다.
+                    
+                    - 상위 10명의 랭킹 목록을 반환합니다.
+                    - 본인이 11위 이하인 경우 myRank에 별도 포함됩니다.
+                    - 본인이 TOP 10 안이거나 점수 0점이면 myRank는 null입니다.
+                    - 매주 일요일 21:00에 자동 갱신됩니다.
+                    """
+    )
+    @GetMapping("/total")
+    public ApiResponse<TotalRankingResponse> getTotalRanking(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.success(rankingService.getTotalRanking(userId));
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/ranking/dto/response/RankingResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/ranking/dto/response/RankingResponse.java
@@ -1,0 +1,35 @@
+package com.kauniv.lightrip.domain.ranking.dto.response;
+
+import com.kauniv.lightrip.domain.ranking.entity.Ranking;
+import com.kauniv.lightrip.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "랭킹 항목")
+public record RankingResponse(
+
+        @Schema(description = "순위")
+        Integer rank,
+
+        @Schema(description = "사용자 ID")
+        Long userId,
+
+        @Schema(description = "닉네임")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL")
+        String profileImageUrl,
+
+        @Schema(description = "주간 점수 (좋아요×2 + 스크랩×3)")
+        Integer score
+) {
+    public static RankingResponse from(Ranking ranking) {
+        User user = ranking.getUser();
+        return new RankingResponse(
+                ranking.getRankingPosition(),
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImg(),
+                ranking.getScore()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/ranking/dto/response/TotalRankingResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/ranking/dto/response/TotalRankingResponse.java
@@ -1,0 +1,16 @@
+package com.kauniv.lightrip.domain.ranking.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "전체 주간 랭킹 응답")
+public record TotalRankingResponse(
+
+        @Schema(description = "TOP 10 랭킹 목록")
+        List<RankingResponse> topRankings,
+
+        @Schema(description = "내 순위 (TOP 10 안이면 null, 점수 0점이면 null)")
+        RankingResponse myRank
+) {
+}

--- a/src/main/java/com/kauniv/lightrip/domain/ranking/entity/Ranking.java
+++ b/src/main/java/com/kauniv/lightrip/domain/ranking/entity/Ranking.java
@@ -29,15 +29,15 @@ public class Ranking {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "like_count", nullable = false)
-    private Integer likeCount;
+    @Column(name = "score", nullable = false)
+    private Integer score;  // 주간 가중치 합산 점수: (좋아요 × 2) + (스크랩 × 3)
 
     @Enumerated(EnumType.STRING)
     @Column(name = "district", length = 50)
-    private District district;
+    private District district;  // NULL이면 전체 랭킹, 값 있으면 구별 랭킹
 
-    @Column(name = "rank", nullable = false)
-    private Integer rank;
+    @Column(name = "ranking_position", nullable = false)
+    private Integer rankingPosition;
 
     @Column(name = "week_start_at", nullable = false)
     private LocalDateTime weekStartAt;

--- a/src/main/java/com/kauniv/lightrip/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/ranking/repository/RankingRepository.java
@@ -2,6 +2,48 @@ package com.kauniv.lightrip.domain.ranking.repository;
 
 import com.kauniv.lightrip.domain.ranking.entity.Ranking;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
+
+    /**
+     * 전체 랭킹 TOP 10 조회 (district IS NULL = 전체 랭킹)
+     */
+    List<Ranking> findTop10ByDistrictIsNullOrderByRankingPositionAsc();
+
+    /**
+     * 특정 유저의 전체 랭킹 순위 조회
+     */
+    Optional<Ranking> findByUser_IdAndDistrictIsNull(Long userId);
+
+    /**
+     * 주간 점수 집계 Native Query
+     * 지난 7일간 받은 좋아요(×2) + 스크랩(×3)을 유저별로 합산
+     */
+    @Query(nativeQuery = true, value = """
+            SELECT
+                p.user_id AS userId,
+                COALESCE(SUM(l.like_score), 0) + COALESCE(SUM(s.scrap_score), 0) AS totalScore
+            FROM passport p
+            LEFT JOIN (
+                SELECT passport_id, COUNT(*) * 2 AS like_score
+                FROM likes
+                WHERE created_at >= NOW() - INTERVAL '7 days'
+                GROUP BY passport_id
+            ) l ON l.passport_id = p.passport_id
+            LEFT JOIN (
+                SELECT passport_id, COUNT(*) * 3 AS scrap_score
+                FROM scrap
+                WHERE created_at >= NOW() - INTERVAL '7 days'
+                GROUP BY passport_id
+            ) s ON s.passport_id = p.passport_id
+            GROUP BY p.user_id
+            HAVING COALESCE(SUM(l.like_score), 0) + COALESCE(SUM(s.scrap_score), 0) > 0
+            ORDER BY totalScore DESC, p.user_id ASC
+            """)
+    List<Object[]> calculateWeeklyScores();
 }

--- a/src/main/java/com/kauniv/lightrip/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/ranking/service/RankingService.java
@@ -1,0 +1,112 @@
+package com.kauniv.lightrip.domain.ranking.service;
+
+import com.kauniv.lightrip.domain.ranking.dto.response.RankingResponse;
+import com.kauniv.lightrip.domain.ranking.dto.response.TotalRankingResponse;
+import com.kauniv.lightrip.domain.ranking.entity.Ranking;
+import com.kauniv.lightrip.domain.ranking.repository.RankingRepository;
+import com.kauniv.lightrip.domain.user.entity.User;
+import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 전체 주간 랭킹 조회 (TOP 10 + 내 순위)
+     */
+    public TotalRankingResponse getTotalRanking(Long currentUserId) {
+        // TOP 10 조회
+        List<Ranking> top10 = rankingRepository.findTop10ByDistrictIsNullOrderByRankingPositionAsc();
+        List<RankingResponse> topRankings = top10.stream()
+                .map(RankingResponse::from)
+                .toList();
+
+        // 내가 TOP 10 안에 있는지 확인
+        boolean isInTop10 = top10.stream()
+                .anyMatch(r -> r.getUser().getId().equals(currentUserId));
+
+        // TOP 10 밖이면 내 순위 별도 조회
+        RankingResponse myRank = null;
+        if (!isInTop10) {
+            myRank = rankingRepository.findByUser_IdAndDistrictIsNull(currentUserId)
+                    .map(RankingResponse::from)
+                    .orElse(null);  // 점수 0점이면 null
+        }
+
+        return new TotalRankingResponse(topRankings, myRank);
+    }
+
+    /**
+     * 주간 랭킹 산정 (스케줄러에서 호출)
+     * 1. 기존 랭킹 전체 삭제
+     * 2. 지난 7일간 점수 집계
+     * 3. 순위 부여 후 저장
+     */
+    @Transactional
+    public void calculateAndSaveRanking() {
+        log.info("=== 주간 랭킹 산정 시작 ===");
+
+        // 1. 기존 전체 삭제
+        rankingRepository.deleteAllInBatch();
+
+        // 2. 점수 집계
+        List<Object[]> scores = rankingRepository.calculateWeeklyScores();
+        log.info("점수 집계 완료: {}명", scores.size());
+
+        if (scores.isEmpty()) {
+            log.info("=== 이번 주 점수가 있는 유저 없음, 랭킹 산정 종료 ===");
+            return;
+        }
+
+        // 3. 이번 주 월요일 00:00 계산
+        LocalDateTime weekStartAt = LocalDateTime.now()
+                .with(DayOfWeek.MONDAY)
+                .with(LocalTime.MIDNIGHT);
+
+        // 4. Ranking 엔티티 생성
+        List<Ranking> rankings = new ArrayList<>();
+        int rank = 1;
+
+        for (Object[] row : scores) {
+            Long userId = ((Number) row[0]).longValue();
+            Integer totalScore = ((Number) row[1]).intValue();
+
+            User user = userRepository.findById(userId)
+                    .orElse(null);
+
+            if (user == null) {
+                log.warn("유저 {}를 찾을 수 없어 랭킹에서 제외", userId);
+                continue;
+            }
+
+            rankings.add(Ranking.builder()
+                    .user(user)
+                    .score(totalScore)
+                    .district(null)  // 전체 랭킹
+                    .rankingPosition(rank++)
+                    .weekStartAt(weekStartAt)
+                    .build());
+        }
+
+        // 5. 일괄 저장
+        rankingRepository.saveAll(rankings);
+        log.info("=== 주간 랭킹 산정 완료: {}명 저장 ===", rankings.size());
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -52,7 +52,11 @@ public enum ErrorCode {
     FRIEND_ALREADY_REQUESTED(HttpStatus.CONFLICT, "F002", "이미 친구 요청을 보냈거나 친구 관계입니다."),
     FRIEND_SELF_REQUEST(HttpStatus.BAD_REQUEST, "F003", "자기 자신에게 친구 요청을 보낼 수 없습니다."),
     FRIEND_NOT_RECEIVER(HttpStatus.FORBIDDEN, "F004", "친구 요청을 수락/거절할 권한이 없습니다."),
-    FRIEND_NOT_MEMBER(HttpStatus.FORBIDDEN, "F005", "해당 친구 관계의 당사자가 아닙니다.");
+    FRIEND_NOT_MEMBER(HttpStatus.FORBIDDEN, "F005", "해당 친구 관계의 당사자가 아닙니다."),
+
+    // ===== Ranking =====
+    RANKING_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "랭킹 정보가 존재하지 않습니다."),
+    RANKING_CALCULATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R002", "랭킹 산정 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #49

## 📝 작업 내용

지난 1주일간 사용자가 받은 좋아요(×2)와 스크랩(×3)을 가중치 기반으로 집계하여 주간 랭킹을 제공하는 API를 구현하였습니다. 매주 일요일 21시에 자동 갱신되며, 상위 10명과 함께 본인 순위를 응답합니다.

| Name | Method | URL |
|---|---|---|
| 전체 주간 랭킹 조회 | `GET` | `/api/v1/rankings/total` |

### 변경 사항

**엔티티 수정**
- `Ranking.like_count` → `score`로 컬럼명 변경 (가중치 합산 점수 반영)
- `Ranking.rank` → `ranking_position`으로 컬럼명 변경 (PostgreSQL 예약어 회피)

**신규 생성**
- `RankingResponse` — 랭킹 항목 응답 DTO (rank, userId, nickname, profileImageUrl, score)
- `TotalRankingResponse` — TOP 10 + 내 순위 응답 DTO
- `RankingService` — 랭킹 조회 + 산정 배치 로직
- `RankingController` — `GET /api/v1/rankings/total` 엔드포인트
- `RankingScheduler` — 매주 일요일 21:00 자동 갱신 (cron: `0 0 21 ? * SUN`)

**기존 파일 수정**
- `LightripApplication` — `@EnableScheduling` 추가
- `ErrorCode` — R001(RANKING_NOT_FOUND), R002(RANKING_CALCULATION_FAILED) 추가
- `RankingRepository` — TOP 10 조회, 내 순위 조회, 점수 집계 Native Query 추가

### 랭킹 정책

| 항목 | 내용 |
|---|---|
| 점수 산정 | (좋아요 수 × 2) + (스크랩 수 × 3) |
| 집계 기준 | 최근 7일 이내 (Like/Scrap의 created_at 기준) |
| 갱신 주기 | 매주 일요일 21:00 |
| 갱신 방식 | 전체 삭제 후 재계산 (히스토리 없음) |
| 동점 처리 | score DESC → user_id ASC |
| 노출 | TOP 10 + 본인 11위 이하 시 myRank 별도 포함 |

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

