### PR TITLE
FEAT: 팀 API 기반 엔티티/레포지토리 세팅

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -147,4 +147,6 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
         """)
     List<Passport> findPublicPassportsByUserId(@Param("userId") Long userId,
                                                Pageable pageable);
+
+    List<Passport> findAllByTeam_Id(Long teamId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/team/entity/Team.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/entity/Team.java
@@ -27,8 +27,8 @@ public class Team {
     @Column(name = "team_name", length = 50, nullable = false)
     private String teamName;
 
-    @Column(name = "invite_code", length = 50, unique = true, nullable = false)
-    private String inviteCode;
+    @Column(name = "team_code", length = 50, unique = true, nullable = false)
+    private String teamCode;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
@@ -3,7 +3,16 @@ package com.kauniv.lightrip.domain.team.repository;
 import com.kauniv.lightrip.domain.team.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
     boolean existsByTeam_IdAndUser_Id(Long teamId, Long userId);
+
+    List<TeamMember> findAllByTeam_Id(Long teamId);
+
+    Optional<TeamMember> findByTeam_IdAndUser_Id(Long teamId, Long userId);
+
+    Optional<TeamMember> findByTeam_IdAndRole(Long teamId, TeamMember.Role role);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamRepository.java
@@ -3,5 +3,9 @@ package com.kauniv.lightrip.domain.team.repository;
 import com.kauniv.lightrip.domain.team.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    Optional<Team> findByTeamCode(String teamCode);
 }

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -38,7 +38,10 @@ public enum ErrorCode {
     // ===== Team =====
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "존재하지 않는 팀입니다."),
     TEAM_ALREADY_JOINED(HttpStatus.CONFLICT, "T002", "이미 가입된 팀이 있습니다."),
-    TEAM_INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "T003", "유효하지 않은 초대 코드입니다."),
+    TEAM_INVALID_CODE(HttpStatus.BAD_REQUEST, "T003", "유효하지 않은 팀 코드입니다."),
+    TEAM_NOT_MEMBER(HttpStatus.FORBIDDEN, "T004", "팀 멤버가 아닙니다."),
+    TEAM_LEADER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "T005", "팀장은 팀을 탈퇴할 수 없습니다."),
+    TEAM_FULL(HttpStatus.CONFLICT, "T006", "팀 인원이 가득 찼습니다."),
 
     // ===== Map =====
     REVERSE_GEOCODE_FAILED(HttpStatus.BAD_GATEWAY, "M001", "역지오코딩에 실패했습니다."),


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #56

## 📝 작업 내용

팀 API 구현을 위한 기반 작업입니다.

**변경 사항**

엔티티 수정
- Team — `inviteCode` → `teamCode` 필드명/컬럼명 변경 (`invite_code` → `team_code`)
- EC2 RDS 직접 ALTER 적용

기존 파일 수정
- TeamRepository — `findByTeamCode` 추가
- TeamMemberRepository — `findAllByTeam_Id`, `findByTeam_IdAndUser_Id`, `findByTeam_IdAndRole` 추가
- PassportRepository — `findAllByTeam_Id` 추가
- ErrorCode — T004(`TEAM_NOT_MEMBER`), T005(`TEAM_LEADER_CANNOT_LEAVE`), T006(`TEAM_FULL`) 추가

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
