### PR TITLE
FEAT: Prometheus 메트릭 엔드포인트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// Monitoring
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.25.60'
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,3 +62,8 @@ cloud.aws.credentials.access-key=${AWS_ACCESS_KEY_ID}
 cloud.aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY}
 cloud.aws.stack.auto=false
 cloud.cloudfront.domain=${CLOUDFRONT_DOMAIN}
+
+# Monitoring (Prometheus + Grafana)
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.prometheus.enabled=true
+management.metrics.tags.application=${spring.application.name}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #61

## 📝 작업 내용
Grafana Cloud 기반 모니터링 환경을 구축하였습니다.

**변경 사항**

기존 파일 수정
- build.gradle — micrometer-registry-prometheus 의존성 추가
- application.properties — Actuator prometheus 엔드포인트 노출 설정 추가

인프라 작업 (코드 외)
- EC2에 Grafana Alloy 설치 및 systemd 서비스 등록
- Grafana Cloud 스택 생성 및 Alloy → Grafana Cloud 메트릭 수집 파이프라인 구성

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

