### PR TITLE
FEAT: 친구 목록 및 추천 친구 응답에 도장 수 / 공통 친구 목록 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
@@ -4,6 +4,7 @@ import com.kauniv.lightrip.domain.friend.entity.Friend;
 import com.kauniv.lightrip.domain.user.entity.User;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record FriendResponse(
         Long friendId,
@@ -12,7 +13,9 @@ public record FriendResponse(
         String profileImg,
         String friendCode,
         String status,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        Long passportCount,
+        List<MutualFriendInfo> mutualFriends
 ) {
     public static FriendResponse from(Friend friend, User target) {
         return new FriendResponse(
@@ -22,7 +25,55 @@ public record FriendResponse(
                 target.getProfileImg(),
                 target.getFriendCode(),
                 friend.getStatus().name(),
-                friend.getCreatedAt()
+                friend.getCreatedAt(),
+                null,
+                null
         );
+    }
+
+    public static FriendResponse from(Friend friend, User target,
+                                      Long passportCount,
+                                      List<MutualFriendInfo> mutualFriends) {
+        return new FriendResponse(
+                friend.getId(),
+                target.getId(),
+                target.getNickname(),
+                target.getProfileImg(),
+                target.getFriendCode(),
+                friend.getStatus().name(),
+                friend.getCreatedAt(),
+                passportCount,
+                mutualFriends
+        );
+    }
+
+    public static FriendResponse ofUser(User user,
+                                        Long passportCount,
+                                        List<MutualFriendInfo> mutualFriends) {
+        return new FriendResponse(
+                null,
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImg(),
+                user.getFriendCode(),
+                null,
+                null,
+                passportCount,
+                mutualFriends
+        );
+    }
+
+    public record MutualFriendInfo(
+            Long userId,
+            String nickname,
+            String profileImg
+    ) {
+        public static MutualFriendInfo from(User user) {
+            return new MutualFriendInfo(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getProfileImg()
+            );
+        }
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
@@ -1,6 +1,7 @@
 package com.kauniv.lightrip.domain.friend.repository;
 
 import com.kauniv.lightrip.domain.friend.entity.Friend;
+import com.kauniv.lightrip.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -46,4 +47,21 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             """)
     List<Long> findFriendUserIdsAmong(@Param("userId") Long userId,
                                       @Param("otherIds") List<Long> otherIds);
+
+    // 두 유저의 공통 친구 목록 조회
+    @Query("""
+            SELECT CASE WHEN f1.requester.id = :userA THEN f1.receiver ELSE f1.requester END
+            FROM Friend f1
+            WHERE f1.status = 'ACCEPTED'
+              AND (f1.requester.id = :userA OR f1.receiver.id = :userA)
+              AND (
+                CASE WHEN f1.requester.id = :userA THEN f1.receiver.id ELSE f1.requester.id END
+              ) IN (
+                SELECT CASE WHEN f2.requester.id = :userB THEN f2.receiver.id ELSE f2.requester.id END
+                FROM Friend f2
+                WHERE f2.status = 'ACCEPTED'
+                  AND (f2.requester.id = :userB OR f2.receiver.id = :userB)
+              )
+            """)
+    List<User> findMutualFriends(@Param("userA") Long userA, @Param("userB") Long userB);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -99,12 +99,39 @@ public class FriendService {
     public List<FriendResponse> getFriends(Long userId) {
         List<Friend> friends = friendRepository.findAllFriends(userId);
 
+        if (friends.isEmpty()) {
+            return List.of();
+        }
+
+        // 친구 유저 ID 목록 추출
+        List<Long> targetIds = friends.stream()
+                .map(f -> f.getRequester().getId().equals(userId)
+                        ? f.getReceiver().getId()
+                        : f.getRequester().getId())
+                .toList();
+
+        // 도장 수 일괄 조회
+        Map<Long, Long> passportCountMap = passportRepository.countByUserIds(targetIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
         return friends.stream()
                 .map(friend -> {
                     User target = friend.getRequester().getId().equals(userId)
                             ? friend.getReceiver()
                             : friend.getRequester();
-                    return FriendResponse.from(friend, target);
+
+                    Long passportCount = passportCountMap.getOrDefault(target.getId(), 0L);
+
+                    // 공통 친구 목록 조회
+                    List<FriendResponse.MutualFriendInfo> mutualFriends =
+                            friendRepository.findMutualFriends(userId, target.getId()).stream()
+                                    .map(FriendResponse.MutualFriendInfo::from)
+                                    .toList();
+
+                    return FriendResponse.from(friend, target, passportCount, mutualFriends);
                 })
                 .toList();
     }
@@ -128,11 +155,12 @@ public class FriendService {
                 user.getProfileImg(),
                 user.getFriendCode(),
                 null,
+                null,
+                null,
                 null
         );
     }
 
-    // 친구 여권 조회 — ACCEPTED 친구 관계 확인 후 PUBLIC 여권만 반환
     public List<FriendPassportResponse> getFriendPassports(Long currentUserId,
                                                            Long friendId,
                                                            Pageable pageable) {
@@ -149,7 +177,6 @@ public class FriendService {
                 .toList();
     }
 
-    // 친구 지도 조회 — PUBLIC 여권 기준 district 목록 반환
     public List<DistrictResponse> getFriendDistricts(Long currentUserId, Long friendId) {
         if (!friendRepository.isFriend(currentUserId, friendId)) {
             throw new BusinessException(ErrorCode.FRIEND_NOT_MEMBER);
@@ -176,23 +203,19 @@ public class FriendService {
                 .toList();
     }
 
-    // 추천 친구 조회 — 내가 스크랩한 여권 작성자 중 아직 친구가 아닌 유저 최대 4명 랜덤 반환
     public List<FriendResponse> getRecommendedFriends(Long userId) {
-        // 1. 내가 스크랩한 여권의 작성자 ID 목록 (본인 제외)
         List<Long> candidateIds = scrapRepository.findScrapedPassportOwnerIds(userId);
 
         if (candidateIds.isEmpty()) {
             return List.of();
         }
 
-        // 2. 이미 친구이거나 요청 중인 유저 제외
         Set<Long> existingFriendIds = friendRepository.findAllFriends(userId).stream()
                 .map(f -> f.getRequester().getId().equals(userId)
                         ? f.getReceiver().getId()
                         : f.getRequester().getId())
                 .collect(Collectors.toSet());
 
-        // PENDING 상태도 제외
         Set<Long> pendingIds = friendRepository.findPendingRequests(userId).stream()
                 .map(f -> f.getRequester().getId())
                 .collect(Collectors.toSet());
@@ -201,7 +224,6 @@ public class FriendService {
                 .filter(id -> !existingFriendIds.contains(id) && !pendingIds.contains(id))
                 .collect(Collectors.toList());
 
-        // 3. 랜덤 셔플 후 최대 4명 추출
         Collections.shuffle(filteredIds);
         List<Long> selectedIds = filteredIds.stream().limit(4).toList();
 
@@ -209,17 +231,25 @@ public class FriendService {
             return List.of();
         }
 
-        // 4. User 정보 조회 후 응답 변환
+        // 도장 수 일괄 조회
+        Map<Long, Long> passportCountMap = passportRepository.countByUserIds(selectedIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
         return userRepository.findAllById(selectedIds).stream()
-                .map(user -> new FriendResponse(
-                        null,
-                        user.getId(),
-                        user.getNickname(),
-                        user.getProfileImg(),
-                        user.getFriendCode(),
-                        null,
-                        null
-                ))
+                .map(user -> {
+                    Long passportCount = passportCountMap.getOrDefault(user.getId(), 0L);
+
+                    // 공통 친구 목록 조회
+                    List<FriendResponse.MutualFriendInfo> mutualFriends =
+                            friendRepository.findMutualFriends(userId, user.getId()).stream()
+                                    .map(FriendResponse.MutualFriendInfo::from)
+                                    .toList();
+
+                    return FriendResponse.ofUser(user, passportCount, mutualFriends);
+                })
                 .toList();
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -149,4 +149,13 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
                                                Pageable pageable);
 
     List<Passport> findAllByTeam_Id(Long teamId);
+
+    // 여러 유저의 도장 수를 한번에 조회 (N+1 방지)
+    @Query("""
+    SELECT p.user.id, COUNT(p)
+    FROM Passport p
+    WHERE p.user.id IN :userIds
+    GROUP BY p.user.id
+    """)
+    List<Object[]> countByUserIds(@Param("userIds") List<Long> userIds);
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #64

## 📝 작업 내용

- [x] `FriendRepository`에 `findMutualFriends()` 추가 — 두 유저의 공통 친구 목록 조회
- [x] `PassportRepository`에 `countByUserIds()` 추가 — 여러 유저의 도장 수 일괄 조회 (N+1 방지)
- [x] `FriendResponse`에 `passportCount`, `mutualFriends` 필드 추가
- [x] `FriendService.getFriends()` 수정 — 도장 수 및 공통 친구 목록 포함하여 반환
- [x] `FriendService.getRecommendedFriends()` 수정 — 도장 수 및 공통 친구 목록 포함하여 반환

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

