### PR TITLE
FEAT: WebSocket + STOMP 팀 실시간 지도 동기화 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 	// Monitoring
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.25.60'
 

--- a/src/main/java/com/kauniv/lightrip/domain/team/controller/MapSyncController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/controller/MapSyncController.java
@@ -1,0 +1,22 @@
+package com.kauniv.lightrip.domain.team.controller;
+
+import com.kauniv.lightrip.domain.team.dto.request.LocationMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MapSyncController {
+
+    @MessageMapping("/team/{teamId}/location")
+    @SendTo("/topic/team/{teamId}")
+    public LocationMessage syncLocation(
+            @DestinationVariable Long teamId,
+            LocationMessage message
+    ) {
+        return message;
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/team/dto/request/LocationMessage.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/dto/request/LocationMessage.java
@@ -1,0 +1,17 @@
+package com.kauniv.lightrip.domain.team.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationMessage {
+    private Long userId;
+    private String nickname;
+    private Double latitude;
+    private Double longitude;
+    private String placeName;
+    private Long passportId;
+}

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/", "/oauth2/**", "/login/**", "/auth/refresh",
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
-                                "/actuator/**"
+                                "/actuator/**", "/ws/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/{userId}").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/kauniv/lightrip/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.kauniv.lightrip.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #66 

## 📝 작업 내용

WebSocket + STOMP 기반 팀 실시간 지도 동기화 기능을 구현하였습니다.

**신규 생성**
- WebSocketConfig — STOMP 엔드포인트(/ws), Simple Broker(/topic), 앱 prefix(/app) 설정
- LocationMessage — WebSocket 송수신 메시지 DTO (userId, nickname, 좌표, 장소명, passportId)
- MapSyncController — /app/team/{teamId}/location 수신 → /topic/team/{teamId} 브로드캐스트

**기존 파일 수정**
- build.gradle — spring-boot-starter-websocket 의존성 추가
- SecurityConfig — /ws/** 경로 permitAll 추가

| 구분 | 내용 |
|---|---|
| WebSocket 엔드포인트 | /ws (SockJS 지원) |
| 구독 경로 | /topic/team/{teamId} |
| 메시지 전송 경로 | /app/team/{teamId}/location |
| 브로커 방식 | Simple Broker (단일 인스턴스) |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

