### PR TITLE
FEAT: AI 초안 생성 및 카테고리 초기값 저장 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
@@ -19,9 +19,17 @@ public record PassportCreateRequest(
         @Size(min = 1, max = 5, message = "이미지는 1장 이상 5장 이하여야 합니다.")
         List<@NotBlank(message = "이미지 URL은 비어있을 수 없습니다.") String> imageUrls,
 
-        @Schema(description = "기록 내용", example = "오늘 다녀온 카페, 분위기 너무 좋았다.")
+        @Schema(description = "기록 내용 (사용자가 수정한 최종본)", example = "오늘 다녀온 카페, 분위기 너무 좋았다.")
         @NotBlank(message = "기록 내용은 필수입니다.")
         String content,
+
+        @Schema(description = "AI가 생성한 초안 원본 (학습 데이터용)", example = "창가에 앉아 커피 향을...")
+        String draft,
+        // > AI 초안 API 호출 결과. 사용자가 수정 전 원본. nullable (AI 미사용 시).
+
+        @Schema(description = "AI가 분류한 카테고리 초기값 (학습 데이터용)", example = "CAFE")
+        Category aiCategory,
+        // > AI 카테고리 초기값. 사용자가 category를 바꿔도 보존. nullable.
 
         @Schema(description = "위도", example = "37.5665")
         @NotNull(message = "위도는 필수입니다.")
@@ -49,7 +57,7 @@ public record PassportCreateRequest(
         @Size(max = 50)
         String spaceName,
 
-        @Schema(description = "카테고리", example = "CAFE")
+        @Schema(description = "카테고리 (사용자 최종 선택값)", example = "CAFE")
         @NotNull(message = "카테고리는 필수입니다.")
         Category category,
 
@@ -71,7 +79,7 @@ public record PassportCreateRequest(
         @Schema(description = "팀 ID (개인 여권이면 null)")
         Long teamId
 ) {
-    public Visibility visibilityOrDefault() {
-        return visibility == null ? Visibility.PUBLIC : visibility;
-    }
+        public Visibility visibilityOrDefault() {
+                return visibility == null ? Visibility.PUBLIC : visibility;
+        }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
@@ -6,11 +6,7 @@ import com.kauniv.lightrip.global.enums.Category;
 import com.kauniv.lightrip.global.enums.District;
 import com.kauniv.lightrip.global.enums.Visibility;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -56,6 +52,18 @@ public class Passport {
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
+
+    @Column(name = "draft", columnDefinition = "TEXT")
+    private String draft;
+    // > AI가 생성한 블로그 초안 원본.
+    // > 사용자가 content를 수정해도 초안은 보존 → 향후 학습 데이터셋으로 활용.
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ai_category", length = 20)
+    private Category aiCategory;
+    // > AI가 분류한 카테고리 초기값.
+    // > 사용자가 category를 바꿔도 ai_category는 보존.
+    // > category != ai_category 케이스 분석으로 모델 개선에 활용.
 
     @Column(name = "latitude", precision = 10, scale = 7, nullable = false)
     private BigDecimal latitude;
@@ -109,14 +117,9 @@ public class Passport {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-
-    public void update(String content,
-                       String spaceName,
-                       Category category,
-                       District districtCategory,
-                       Visibility visibility,
-                       String musicTitle,
-                       String musicArtist) {
+    public void update(String content, String spaceName, Category category,
+                       District districtCategory, Visibility visibility,
+                       String musicTitle, String musicArtist) {
         this.content = content;
         this.spaceName = spaceName;
         this.category = category;
@@ -143,37 +146,16 @@ public class Passport {
         this.visibility = visibility;
     }
 
-    /**
-     * 해당 사용자가 이 여권의 작성자인지 확인
-     */
     public boolean isOwnedBy(Long userId) {
         return this.user.getId().equals(userId);
     }
 
-    /**
-     * 팀 모드 여권 여부
-     */
     public boolean isTeamPassport() {
         return this.team != null;
     }
 
-    // ============================================================
-    // 좋아요 / 스크랩 카운트
-    // ============================================================
-
-    public void increaseLikeCount() {
-        this.likeCount++;
-    }
-
-    public void decreaseLikeCount() {
-        if (this.likeCount > 0) this.likeCount--;
-    }
-
-    public void increaseScrapCount() {
-        this.scrapCount++;
-    }
-
-    public void decreaseScrapCount() {
-        if (this.scrapCount > 0) this.scrapCount--;
-    }
+    public void increaseLikeCount() { this.likeCount++; }
+    public void decreaseLikeCount() { if (this.likeCount > 0) this.likeCount--; }
+    public void increaseScrapCount() { this.scrapCount++; }
+    public void decreaseScrapCount() { if (this.scrapCount > 0) this.scrapCount--; }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -20,6 +20,7 @@ import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.enums.District;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,7 +44,7 @@ import java.util.Set;
 import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
 import com.kauniv.lightrip.global.enums.Visibility;
 
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -82,6 +83,10 @@ public class PassportService {
                 .user(user)
                 .team(team)
                 .content(req.content())
+                .draft(req.draft())
+                .aiCategory(req.aiCategory())
+                // > 프론트에서 AI 초안 API 호출 결과를 전달받아 저장.
+                // > draft: 초안 원본, aiCategory: AI 분류 카테고리 초기값.
                 .latitude(req.latitude())
                 .longitude(req.longitude())
                 .address(req.address())
@@ -108,9 +113,7 @@ public class PassportService {
     public PassportResponse getPassport(Long userId, Long passportId) {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
-
         validateReadPermission(passport, userId);
-
         return PassportResponse.from(passport);
     }
 
@@ -119,17 +122,10 @@ public class PassportService {
     public PassportResponse update(Long userId, Long passportId, PassportUpdateRequest req) {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
-
         validateUpdatePermission(passport, userId);
-
-        passport.update(
-                req.content(), req.spaceName(),
-                req.category(), req.districtCategory(), req.visibility(),
-                req.musicTitle(), req.musicArtist()
-        );
-
+        passport.update(req.content(), req.spaceName(), req.category(),
+                req.districtCategory(), req.visibility(), req.musicTitle(), req.musicArtist());
         passport.replaceImages(req.imageUrls());
-
         return PassportResponse.from(passport);
     }
 
@@ -139,14 +135,10 @@ public class PassportService {
                                              PassportVisibilityRequest req) {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
-
-        // 본인 여권만 공개 범위 변경 가능 (팀 여권도 작성자만)
         if (!passport.isOwnedBy(userId)) {
             throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
-
         passport.updateVisibility(req.visibility());
-
         return PassportResponse.from(passport);
     }
 
@@ -155,13 +147,10 @@ public class PassportService {
     public void delete(Long userId, Long passportId) {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
-
         if (!passport.isOwnedBy(userId)) {
             throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
-
         District district = passport.getDistrictCategory();
-
         likeRepository.deleteAllByPassportId(passportId);
         scrapRepository.deleteAllByPassportId(passportId);
         passportRepository.delete(passport);
@@ -180,16 +169,13 @@ public class PassportService {
     // ========== DistrictCover 자동 생성 ==========
     private void createDistrictCoverIfFirst(User user, Passport passport) {
         District district = passport.getDistrictCategory();
-
         if (!districtCoverRepository.existsByUser_IdAndDistrictCategory(user.getId(), district)) {
             PassportImage firstImage = passport.getImages().get(0);
-
             DistrictCover cover = DistrictCover.builder()
                     .user(user)
                     .passportImage(firstImage)
                     .districtCategory(district)
                     .build();
-
             districtCoverRepository.save(cover);
         }
     }
@@ -213,10 +199,7 @@ public class PassportService {
     // ========== 수정 권한 검증 ==========
     private void validateUpdatePermission(Passport passport, Long userId) {
         if (passport.isTeamPassport()) {
-            boolean isMember = teamMemberRepository.existsByTeam_IdAndUser_Id(
-                    passport.getTeam().getId(), userId
-            );
-            if (!isMember) {
+            if (!teamMemberRepository.existsByTeam_IdAndUser_Id(passport.getTeam().getId(), userId)) {
                 throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
             }
         } else {
@@ -226,31 +209,18 @@ public class PassportService {
         }
     }
 
-    // ========== 조회 권한 검증 (Visibility) ==========
+    // ========== 조회 권한 검증 ==========
     private void validateReadPermission(Passport passport, Long userId) {
-        if (passport.isOwnedBy(userId)) {
-            return;
-        }
-
+        if (passport.isOwnedBy(userId)) return;
         if (passport.isTeamPassport()) {
-            boolean isMember = teamMemberRepository.existsByTeam_IdAndUser_Id(
-                    passport.getTeam().getId(), userId
-            );
-            if (isMember) {
-                return;
-            }
+            if (teamMemberRepository.existsByTeam_IdAndUser_Id(passport.getTeam().getId(), userId)) return;
         }
-
         switch (passport.getVisibility()) {
-            case PUBLIC -> {
-                return;
-            }
+            case PUBLIC -> {}
             case FRIENDS_ONLY -> {
-                Long ownerId = passport.getUser().getId();
-                if (friendRepository.isFriend(userId, ownerId)) {
-                    return;
+                if (!friendRepository.isFriend(userId, passport.getUser().getId())) {
+                    throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
                 }
-                throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
             }
             case PRIVATE -> throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
@@ -259,54 +229,36 @@ public class PassportService {
     // ========== 내 기록 지역 조회 ==========
     public List<DistrictResponse> getMyDistricts(Long userId) {
         List<Object[]> counts = passportRepository.countByUserIdGroupByDistrict(userId);
-
         Map<District, String> coverMap = districtCoverRepository.findAllByUser_Id(userId).stream()
                 .collect(Collectors.toMap(
                         DistrictCover::getDistrictCategory,
                         cover -> cover.getPassportImage().getImageUrl()
                 ));
-
         return counts.stream()
-                .map(row -> {
-                    District district = (District) row[0];
-                    Long count = (Long) row[1];
-                    String thumbnailUrl = coverMap.get(district);
-                    return DistrictResponse.of(district, count, thumbnailUrl);
-                })
+                .map(row -> DistrictResponse.of((District) row[0], (Long) row[1], coverMap.get((District) row[0])))
                 .toList();
     }
 
-    // ========== 내 여권 목록 조회 (장소별, 커서 기반) ==========
-    public CursorResponse<PassportListResponse> getMyPassports(Long userId,
-                                                               Category category,
+    // ========== 내 여권 목록 조회 ==========
+    public CursorResponse<PassportListResponse> getMyPassports(Long userId, Category category,
                                                                District districtCategory,
-                                                               Long cursor,
-                                                               int size) {
+                                                               Long cursor, int size) {
         List<Passport> passports = (cursor == null)
                 ? passportRepository.findMyPassportsFirst(userId, category, districtCategory, PageRequest.of(0, size + 1))
                 : passportRepository.findMyPassportsAfterCursor(userId, cursor, category, districtCategory, PageRequest.of(0, size + 1));
         boolean hasNext = passports.size() > size;
-
-        if (hasNext) {
-            passports = passports.subList(0, size);
-        }
-
-        List<PassportListResponse> content = passports.stream()
-                .map(PassportListResponse::from)
-                .toList();
-
+        if (hasNext) passports = passports.subList(0, size);
         Long nextCursor = hasNext ? passports.get(passports.size() - 1).getId() : null;
-
-        return CursorResponse.of(content, hasNext, nextCursor);
+        return CursorResponse.of(passports.stream().map(PassportListResponse::from).toList(), hasNext, nextCursor);
     }
 
     // ========== 내 여권 통계 조회 ==========
     public PassportStatsResponse getMyStats(Long userId) {
-        long passportCount = passportRepository.countByUser_Id(userId);
-        long likeCount = likeRepository.countByUser_Id(userId);
-        long scrapCount = scrapRepository.countByUser_Id(userId);
-
-        return new PassportStatsResponse(passportCount, likeCount, scrapCount);
+        return new PassportStatsResponse(
+                passportRepository.countByUser_Id(userId),
+                likeRepository.countByUser_Id(userId),
+                scrapRepository.countByUser_Id(userId)
+        );
     }
 
     private static final int EARTH_RADIUS_KM = 6371;
@@ -320,44 +272,29 @@ public class PassportService {
         validateLocation(latitude, longitude);
 
         List<Long> candidateIds = passportRepository.findFeedPassportIds(
-                userId,
-                category != null ? category.name() : null,
+                userId, category != null ? category.name() : null,
                 district != null ? district.name() : null,
                 latitude, longitude, radius, cursor, cursorScore, size + 1
         );
 
-        if (candidateIds.isEmpty()) {
-            return FeedCursorResponse.of(List.of(), false, null, null);
-        }
+        if (candidateIds.isEmpty()) return FeedCursorResponse.of(List.of(), false, null, null);
 
         boolean hasNext = candidateIds.size() > size;
-        if (hasNext) {
-            candidateIds = candidateIds.subList(0, size);
-        }
+        if (hasNext) candidateIds = candidateIds.subList(0, size);
 
         List<Passport> passports = passportRepository.findAllByIdsForFeed(candidateIds);
-
-        Map<Long, Passport> passportMap = passports.stream()
-                .collect(Collectors.toMap(Passport::getId, p -> p));
-        List<Passport> ordered = candidateIds.stream()
-                .map(passportMap::get)
-                .filter(Objects::nonNull)
-                .toList();
+        Map<Long, Passport> passportMap = passports.stream().collect(Collectors.toMap(Passport::getId, p -> p));
+        List<Passport> ordered = candidateIds.stream().map(passportMap::get).filter(Objects::nonNull).toList();
 
         Set<Long> likedIds = new HashSet<>(likeRepository.findLikedPassportIds(userId, candidateIds));
         Set<Long> scrappedIds = new HashSet<>(scrapRepository.findScrappedPassportIds(userId, candidateIds));
-
-        List<Long> writerIds = ordered.stream()
-                .map(p -> p.getUser().getId())
-                .distinct()
-                .toList();
+        List<Long> writerIds = ordered.stream().map(p -> p.getUser().getId()).distinct().toList();
         Set<Long> friendIds = new HashSet<>(friendRepository.findFriendUserIdsAmong(userId, writerIds));
 
         List<FeedPassportResponse> content = ordered.stream()
                 .map(p -> {
                     BigDecimal distance = (latitude != null && longitude != null)
-                            ? calculateDistance(latitude, longitude, p.getLatitude(), p.getLongitude())
-                            : null;
+                            ? calculateDistance(latitude, longitude, p.getLatitude(), p.getLongitude()) : null;
                     return FeedPassportResponse.of(p, likedIds, scrappedIds, friendIds, distance);
                 })
                 .toList();
@@ -373,48 +310,32 @@ public class PassportService {
         return FeedCursorResponse.of(content, hasNext, nextCursor, nextCursorScore);
     }
 
-    // ========== 위치 파라미터 검증 ==========
     private void validateLocation(BigDecimal latitude, BigDecimal longitude) {
         if ((latitude == null) != (longitude == null)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
 
-    // ========== Haversine 거리 계산 ==========
     private BigDecimal calculateDistance(BigDecimal lat1, BigDecimal lng1,
                                          BigDecimal lat2, BigDecimal lng2) {
         double rLat1 = Math.toRadians(lat1.doubleValue());
         double rLat2 = Math.toRadians(lat2.doubleValue());
         double dLat = Math.toRadians(lat2.doubleValue() - lat1.doubleValue());
         double dLng = Math.toRadians(lng2.doubleValue() - lng1.doubleValue());
-
         double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
                 + Math.cos(rLat1) * Math.cos(rLat2)
                 * Math.sin(dLng / 2) * Math.sin(dLng / 2);
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        double distance = EARTH_RADIUS_KM * c;
-
-        return BigDecimal.valueOf(distance).setScale(2, RoundingMode.HALF_UP);
+        return BigDecimal.valueOf(EARTH_RADIUS_KM * c).setScale(2, RoundingMode.HALF_UP);
     }
 
     // ========== 내 불빛 조회 ==========
-    public List<LightResponse> getMyLights(Long userId,
-                                           BigDecimal minLat, BigDecimal maxLat,
+    public List<LightResponse> getMyLights(Long userId, BigDecimal minLat, BigDecimal maxLat,
                                            BigDecimal minLng, BigDecimal maxLng) {
         validateBoundingBox(minLat, maxLat, minLng, maxLng);
-
-        // 본인은 모든 visibility 노출
-        List<Visibility> allowed = List.of(
-                Visibility.PUBLIC,
-                Visibility.PRIVATE,
-                Visibility.FRIENDS_ONLY
-        );
-
-        return passportRepository.findLightsInBounds(
-                        userId, minLat, maxLat, minLng, maxLng, allowed)
-                .stream()
-                .map(LightResponse::from)
-                .toList();
+        return passportRepository.findLightsInBounds(userId, minLat, maxLat, minLng, maxLng,
+                        List.of(Visibility.PUBLIC, Visibility.PRIVATE, Visibility.FRIENDS_ONLY))
+                .stream().map(LightResponse::from).toList();
     }
 
     // ========== 특정 사용자 불빛 조회 ==========
@@ -422,36 +343,20 @@ public class PassportService {
                                              BigDecimal minLat, BigDecimal maxLat,
                                              BigDecimal minLng, BigDecimal maxLng) {
         validateBoundingBox(minLat, maxLat, minLng, maxLng);
-
-        // 본인 조회면 me 메서드로 위임
-        if (viewerId.equals(targetUserId)) {
-            return getMyLights(viewerId, minLat, maxLat, minLng, maxLng);
-        }
-
-        // 대상 사용자 존재 검증
-        if (!userRepository.existsById(targetUserId)) {
-            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
-        }
-
-        // 친구 여부에 따라 visibility 필터링
+        if (viewerId.equals(targetUserId)) return getMyLights(viewerId, minLat, maxLat, minLng, maxLng);
+        if (!userRepository.existsById(targetUserId)) throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         boolean isFriend = friendRepository.isFriend(viewerId, targetUserId);
         List<Visibility> allowed = isFriend
                 ? List.of(Visibility.PUBLIC, Visibility.FRIENDS_ONLY)
                 : List.of(Visibility.PUBLIC);
-
-        return passportRepository.findLightsInBounds(
-                        targetUserId, minLat, maxLat, minLng, maxLng, allowed)
-                .stream()
-                .map(LightResponse::from)
-                .toList();
+        return passportRepository.findLightsInBounds(targetUserId, minLat, maxLat, minLng, maxLng, allowed)
+                .stream().map(LightResponse::from).toList();
     }
 
-    // ========== Bounding Box 검증 ==========
     private void validateBoundingBox(BigDecimal minLat, BigDecimal maxLat,
                                      BigDecimal minLng, BigDecimal maxLng) {
         if (minLat.compareTo(maxLat) > 0 || minLng.compareTo(maxLng) > 0) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }
-
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -1,0 +1,66 @@
+package com.kauniv.lightrip.global.ai;
+
+import com.kauniv.lightrip.global.ai.dto.AiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiClient {
+
+    private final RestClient restClient;
+    // > RestClientConfig에서 Bean으로 등록된 RestClient 주입.
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+    // > application.properties의 ai.server.url 값 주입.
+
+    public AiResponse generate(String imageUrl) {
+        // > CloudFront URL에서 이미지를 다운로드해서 FastAPI로 multipart 전송.
+
+        // 1. 이미지 다운로드
+        ResponseEntity<byte[]> imageResponse = restClient.get()
+                .uri(imageUrl)
+                .retrieve()
+                .toEntity(byte[].class);
+        // > cdn.lightrip.cloud URL로 이미지 byte[] 다운로드.
+
+        byte[] imageBytes = imageResponse.getBody();
+        if (imageBytes == null || imageBytes.length == 0) {
+            log.warn("AI 서버: 이미지 다운로드 실패 - {}", imageUrl);
+            return null;
+        }
+
+        // 2. 파일명 추출
+        String filename = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+        // > URL 마지막 경로에서 파일명 추출. multipart Content-Disposition에 필요.
+
+        // 3. multipart/form-data 구성
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("image", new ByteArrayResource(imageBytes) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        });
+        // > byte[]를 ByteArrayResource로 감싸야 multipart 전송 가능.
+
+        // 4. FastAPI 호출
+        return restClient.post()
+                .uri(aiServerUrl + "/pipeline/generate")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(body)
+                .retrieve()
+                .body(AiResponse.class);
+        // > POST /pipeline/generate 호출 후 AiResponse로 역직렬화.
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/ai/controller/AiController.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/controller/AiController.java
@@ -1,0 +1,29 @@
+package com.kauniv.lightrip.global.ai.controller;
+
+import com.kauniv.lightrip.global.ai.service.AiService;
+import com.kauniv.lightrip.global.ai.dto.AiDraftResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "AI", description = "AI 초안 생성 API")
+@RestController
+@RequestMapping("/api/v1/ai")
+@RequiredArgsConstructor
+public class AiController {
+
+    private final AiService aiService;
+    // > AI 초안 생성 비즈니스 로직 담당.
+
+    @Operation(summary = "AI 초안 생성", description = "이미지 URL로 블로그 초안과 카테고리 초기값을 생성합니다.")
+    @PostMapping("/draft")
+    public ResponseEntity<AiDraftResponse> generateDraft(@RequestParam String imageUrl) {
+        // > 프론트가 S3 업로드 후 받은 CloudFront URL을 전달.
+        // > 여권 등록 전에 호출해서 초안을 미리 보여주는 용도.
+
+        AiDraftResponse response = aiService.generateDraft(imageUrl);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/ai/dto/AiDraftResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/dto/AiDraftResponse.java
@@ -1,0 +1,12 @@
+package com.kauniv.lightrip.global.ai.dto;
+
+import com.kauniv.lightrip.global.enums.Category;
+
+public record AiDraftResponse(
+
+        String draft,
+        // > AI가 생성한 블로그 초안. 프론트에서 content 입력창에 미리 채워줄 값.
+
+        Category category
+        // > AI가 분류한 카테고리. 프론트에서 카테고리 선택창에 미리 선택해줄 값.
+) {}

--- a/src/main/java/com/kauniv/lightrip/global/ai/dto/AiResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/dto/AiResponse.java
@@ -1,0 +1,14 @@
+package com.kauniv.lightrip.global.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AiResponse(
+
+        @JsonProperty("draft")
+        String draft,
+        // > FastAPI가 생성한 블로그 초안 텍스트.
+
+        @JsonProperty("category")
+        String category
+        // > FastAPI가 분류한 카테고리 영문 키값 (CAFE, RESTAURANT 등).
+) {}

--- a/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
@@ -1,0 +1,46 @@
+package com.kauniv.lightrip.global.ai.service;
+
+import com.kauniv.lightrip.global.ai.AiClient;
+import com.kauniv.lightrip.global.ai.dto.AiDraftResponse;
+import com.kauniv.lightrip.global.ai.dto.AiResponse;
+import com.kauniv.lightrip.global.enums.Category;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiService {
+
+    private final AiClient aiClient;
+    // > FastAPI 호출 담당 클라이언트.
+
+    public AiDraftResponse generateDraft(String imageUrl) {
+        // > 이미지 URL로 AI 초안과 카테고리 초기값을 생성해서 반환.
+
+        AiResponse aiResponse = aiClient.generate(imageUrl);
+        // > FastAPI /pipeline/generate 호출.
+
+        if (aiResponse == null) {
+            return new AiDraftResponse(null, null);
+            // > AI 서버 장애 시 null 반환. 프론트에서 빈 값으로 처리.
+        }
+
+        Category category = parseCategory(aiResponse.category());
+        // > FastAPI가 반환한 영문 문자열을 Category enum으로 변환.
+
+        return new AiDraftResponse(aiResponse.draft(), category);
+    }
+
+    private Category parseCategory(String categoryStr) {
+        // > AI 반환값을 Category enum으로 안전하게 변환.
+        // > 매핑 실패 시 ETC로 폴백.
+        try {
+            return Category.valueOf(categoryStr);
+        } catch (IllegalArgumentException e) {
+            log.warn("AI 카테고리 매핑 실패: {} → ETC로 폴백", categoryStr);
+            return Category.ETC;
+        }
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/config/RestClientConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/RestClientConfig.java
@@ -1,0 +1,15 @@
+package com.kauniv.lightrip.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
+        // > AiClient에서 주입받는 RestClient Bean.
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/enums/Category.java
+++ b/src/main/java/com/kauniv/lightrip/global/enums/Category.java
@@ -9,13 +9,11 @@ public enum Category {
 
     CAFE("카페"),
     RESTAURANT("식당"),
-    BAR("술집/바"),
-    TOURIST("관광지"),
-    NATURE("자연/공원"),
-    CULTURE("문화/예술"),
-    ACTIVITY("액티비티"),
-    ACCOMMODATION("숙소"),
+    BAR("술집"),
+    CULTURE("문화"),
+    ACTIVITY("운동"),
     SHOPPING("쇼핑"),
+    NATURE("공원"),
     ETC("기타");
 
     private final String displayName;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,3 +67,6 @@ cloud.cloudfront.domain=${CLOUDFRONT_DOMAIN}
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.prometheus.enabled=true
 management.metrics.tags.application=${spring.application.name}
+
+# AI Server
+ai.server.url=https://ai.lightrip.cloud


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #69

## 📝 작업 내용

이미지 기반 AI 초안 생성 API를 구현하고, 여권 등록 시 AI 초안과 카테고리 초기값을 저장하는 구조를 추가하였습니다.

**신규 생성**
- AiController — POST /api/v1/ai/draft (이미지 URL → 초안 + 카테고리 반환)
- AiService — FastAPI 호출 및 카테고리 enum 변환 로직
- AiClient — CloudFront URL에서 이미지 다운로드 후 FastAPI multipart 전송
- AiResponse — FastAPI 응답 DTO (draft, category)
- AiDraftResponse — 클라이언트 응답 DTO (draft, Category enum)
- RestClientConfig — RestClient Bean 등록

**기존 파일 수정**
- Category — TOURIST, ACCOMMODATION 제거, AI 카테고리 8종으로 통일
- Passport — draft, ai_category 컬럼 추가 (학습 데이터용)
- PassportCreateRequest — draft, aiCategory 필드 추가
- PassportService — 여권 등록 시 프론트에서 받은 draft, aiCategory 저장

| 항목 | 내용 |
|---|---|
| AI 초안 API | POST /api/v1/ai/draft?imageUrl={url} |
| 학습 데이터 | draft(초안 원본) vs content(최종본) 비교로 사용자 선호 패턴 수집 |
| AI 장애 대응 | draft/aiCategory null 허용, 여권 등록은 정상 진행 |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.
