### PR TITLE
FEAT: 여권 도장 기능 추가 및 S3 확인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ out/
 
 ### .env files ###
 .env
+
+
+# Claude 관련 임시 폴더 및 파일 무시
+.claude/
+claude.md
+.claude.md
+*.claude.md

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -129,6 +129,19 @@ public class PassportController {
         return ApiResponse.success(passportService.getMyStats(userId));
     }
 
+    @Operation(summary = "카테고리별 내 여권 조회",
+            description = "특정 카테고리의 내 여권 목록을 조회합니다. 잘못된 카테고리 값 입력 시 400을 반환합니다.")
+    @GetMapping("/categories/{category}")
+    public ApiResponse<CursorResponse<PassportListResponse>> getMyPassportsByCategory(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "카테고리 (CAFE, RESTAURANT, BAR, CULTURE, ACTIVITY, SHOPPING, NATURE, ETC)")
+            @PathVariable Category category,
+            @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 페이지에 가져올 여권 수 (기본값: 10)") @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.success(passportService.getMyPassports(userId, category, null, cursor, size));
+    }
+
     @Operation(summary = "릴스형 여권 피드 조회",
             description = "다른 사용자의 PUBLIC 여권을 인기순으로 조회합니다. 카테고리/지역/위치 필터 지원, 커서 기반 무한스크롤.")
     @GetMapping("/api/v1/feed")

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
@@ -2,6 +2,7 @@ package com.kauniv.lightrip.domain.passport.dto.response;
 
 import com.kauniv.lightrip.domain.passport.entity.Passport;
 import com.kauniv.lightrip.domain.passport.entity.PassportImage;
+import com.kauniv.lightrip.domain.passport.entity.Stamp;
 import com.kauniv.lightrip.global.enums.Category;
 import com.kauniv.lightrip.global.enums.District;
 import com.kauniv.lightrip.global.enums.Visibility;
@@ -32,12 +33,17 @@ public record PassportResponse(
         String musicArtist,
         Long likeCount,
         Long scrapCount,
+        List<String> stampUrls,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
     public static PassportResponse from(Passport p) {
         List<String> urls = p.getImages().stream()
                 .map(PassportImage::getImageUrl)
+                .toList();
+
+        List<String> stamps = p.getStamps().stream()
+                .map(Stamp::getImageUrl)
                 .toList();
 
         return new PassportResponse(
@@ -57,8 +63,9 @@ public record PassportResponse(
                 p.getVisibility(),
                 p.getMusicTitle(),
                 p.getMusicArtist(),
-                p.getLikeCount(),       // 🆕
-                p.getScrapCount(),      // 🆕
+                p.getLikeCount(),
+                p.getScrapCount(),
+                stamps,
                 p.getCreatedAt(),
                 p.getUpdatedAt()
         );

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
@@ -54,6 +54,11 @@ public class Passport {
     @Builder.Default
     private List<PassportImage> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "passport", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    @Builder.Default
+    private List<Stamp> stamps = new ArrayList<>();
+
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Stamp.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Stamp.java
@@ -1,0 +1,49 @@
+package com.kauniv.lightrip.domain.passport.entity;
+
+import com.kauniv.lightrip.global.enums.Category;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "passport_stamp",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_passport_stamp_passport_category",
+                        columnNames = {"passport_id", "category"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Stamp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "passport_stamp_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "passport_id", nullable = false)
+    private Passport passport;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Category category;
+
+    @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
+    private String imageUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -8,6 +8,7 @@ import com.kauniv.lightrip.domain.passport.dto.response.PassportResponse;
 import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
 import com.kauniv.lightrip.domain.passport.entity.Passport;
 import com.kauniv.lightrip.domain.passport.entity.PassportImage;
+import com.kauniv.lightrip.domain.passport.entity.Stamp;
 import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
 import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
 import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
@@ -21,6 +22,7 @@ import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.enums.District;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +60,9 @@ public class PassportService {
     private final FriendRepository friendRepository;
     private final DistrictCoverRepository districtCoverRepository;
     private final LikeRepository likeRepository;
+
+    @Value("${app.stamp.base-url}")
+    private String stampBaseUrl;
 
     // ========== 등록 ==========
     @Transactional
@@ -102,6 +107,7 @@ public class PassportService {
 
         passportRepository.save(passport);
         passport.replaceImages(req.imageUrls());
+        grantStamp(passport);
         passportRepository.flush();
 
         createDistrictCoverIfFirst(user, passport);
@@ -164,6 +170,17 @@ public class PassportService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
         validateReadPermission(passport, userId);
         return passport;
+    }
+
+    // ========== 카테고리 도장 자동 부여 ==========
+    private void grantStamp(Passport passport) {
+        Category category = passport.getCategory();
+        Stamp stamp = Stamp.builder()
+                .passport(passport)
+                .category(category)
+                .imageUrl(stampBaseUrl + "/" + category.name() + ".png")
+                .build();
+        passport.getStamps().add(stamp);
     }
 
     // ========== DistrictCover 자동 생성 ==========

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -20,6 +20,7 @@ import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.enums.District;
+import com.kauniv.lightrip.global.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,6 +61,7 @@ public class PassportService {
     private final FriendRepository friendRepository;
     private final DistrictCoverRepository districtCoverRepository;
     private final LikeRepository likeRepository;
+    private final S3Service s3Service;
 
     @Value("${app.stamp.base-url}")
     private String stampBaseUrl;
@@ -129,9 +131,20 @@ public class PassportService {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
         validateUpdatePermission(passport, userId);
+
+        List<String> oldUrls = passport.getImages().stream()
+                .map(PassportImage::getImageUrl)
+                .toList();
+
         passport.update(req.content(), req.spaceName(), req.category(),
                 req.districtCategory(), req.visibility(), req.musicTitle(), req.musicArtist());
         passport.replaceImages(req.imageUrls());
+
+        Set<String> newUrls = new HashSet<>(req.imageUrls());
+        oldUrls.stream()
+                .filter(url -> !newUrls.contains(url))
+                .forEach(s3Service::deleteFileByUrl);
+
         return PassportResponse.from(passport);
     }
 
@@ -156,11 +169,18 @@ public class PassportService {
         if (!passport.isOwnedBy(userId)) {
             throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
+
+        List<String> imageUrls = passport.getImages().stream()
+                .map(PassportImage::getImageUrl)
+                .toList();
+
         District district = passport.getDistrictCategory();
         likeRepository.deleteAllByPassportId(passportId);
         scrapRepository.deleteAllByPassportId(passportId);
         passportRepository.delete(passport);
         passportRepository.flush();
+
+        imageUrls.forEach(s3Service::deleteFileByUrl);
         cleanupDistrictCover(userId, district);
     }
 

--- a/src/main/java/com/kauniv/lightrip/global/s3/controller/ImageController.java
+++ b/src/main/java/com/kauniv/lightrip/global/s3/controller/ImageController.java
@@ -1,5 +1,7 @@
 package com.kauniv.lightrip.global.s3.controller;
 
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.s3.dto.request.PresignedUrlRequest;
 import com.kauniv.lightrip.global.s3.dto.response.PresignedUrlResponse;
 import com.kauniv.lightrip.global.s3.service.S3Service;
@@ -7,11 +9,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.Set;
 import java.util.UUID;
 
 @Tag(name = "이미지 업로드 API", description = "S3 Presigned URL 기반 이미지 업로드를 제공합니다.")
@@ -20,14 +24,23 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ImageController {
 
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp"
+    );
+
     private final S3Service s3Service;
 
     @Operation(summary = "Presigned URL 발급", description = "S3 업로드용 Presigned URL과 CloudFront 이미지 조회 URL을 반환합니다. 앱은 presignedUrl로 S3에 직접 업로드하고, 완료 후 imageUrl을 DB 저장에 사용합니다.")
     @PostMapping("/presigned-url")
     public ResponseEntity<PresignedUrlResponse> getPresignedUrl(
+            @AuthenticationPrincipal Long userId,
             @RequestBody PresignedUrlRequest request) {
 
-        String s3Key = request.getDomain() + "/" + UUID.randomUUID() + getExtension(request.getContentType());
+        if (!ALLOWED_CONTENT_TYPES.contains(request.getContentType())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        String s3Key = request.getDomain() + "/" + userId + "/" + UUID.randomUUID() + getExtension(request.getContentType());
 
         String presignedUrl = s3Service.generatePresignedUploadUrl(s3Key, request.getContentType());
         String imageUrl = s3Service.getCloudFrontUrl(s3Key);

--- a/src/main/java/com/kauniv/lightrip/global/s3/service/S3Service.java
+++ b/src/main/java/com/kauniv/lightrip/global/s3/service/S3Service.java
@@ -55,4 +55,11 @@ public class S3Service {
                 .build();
         s3Client.deleteObject(deleteRequest);
     }
+
+    // CloudFront URL로 S3 파일 삭제 (외부 URL이면 무시)
+    public void deleteFileByUrl(String imageUrl) {
+        String prefix = "https://" + cloudfrontDomain + "/";
+        if (imageUrl == null || !imageUrl.startsWith(prefix)) return;
+        deleteFile(imageUrl.substring(prefix.length()));
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,3 +70,6 @@ management.metrics.tags.application=${spring.application.name}
 
 # AI Server
 ai.server.url=https://ai.lightrip.cloud
+
+# Stamp
+app.stamp.base-url=https://cdn.lightrip.cloud/stamps


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #71

## 📝 작업 내용

**여권 도장 기능 추가**
- `passport_stamp` 테이블 및 `Stamp` 엔티티 추가 (Passport와 1:N 관계)
- 여권 생성 시 카테고리에 맞는 도장 자동 부여 (S3 stamp 이미지 매핑)
- `PassportResponse`에 `stampUrls` 필드 추가

**S3 이미지 관리 개선**
- Presigned URL S3 키 컨벤션 변경: `passport/{userId}/{uuid}.{ext}`
- 허용되지 않는 이미지 확장자(jpeg·png·webp 외) 요청 시 400 반환
- 여권 수정 시 교체된 이미지 S3에서 자동 삭제
- 여권 삭제 시 연관 이미지 S3에서 일괄 삭제


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.