### PR TITLE
FEAT: /users/me 응답에 districtCount 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -158,4 +158,11 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     GROUP BY p.user.id
     """)
     List<Object[]> countByUserIds(@Param("userIds") List<Long> userIds);
+
+    @Query("""
+    SELECT COUNT(DISTINCT p.districtCategory)
+    FROM Passport p
+    WHERE p.user.id = :userId
+    """)
+    long countDistinctDistrictByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
@@ -26,6 +26,7 @@ public class MyProfileResponse {
     @Builder
     public static class Stats {
         private long passportCount;
+        private long districtCount;
         private long friendCount;
         private long likeCount;
         private long scrapCount;

--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -67,6 +67,7 @@ public class UserService {
 
         MyProfileResponse.Stats stats = MyProfileResponse.Stats.builder()
                 .passportCount(passportRepository.countByUser_Id(userId))
+                .districtCount(passportRepository.countDistinctDistrictByUserId(userId))
                 .friendCount(friendRepository.findAllFriends(userId).size())
                 .likeCount(likeRepository.countByUser_Id(userId))
                 .scrapCount(scrapRepository.countByUser_Id(userId))
@@ -89,6 +90,7 @@ public class UserService {
 
         MyProfileResponse.Stats stats = MyProfileResponse.Stats.builder()
                 .passportCount(passportRepository.countByUser_Id(userId))
+                .districtCount(passportRepository.countDistinctDistrictByUserId(userId))
                 .friendCount(friendRepository.findAllFriends(userId).size())
                 .likeCount(likeRepository.countByUser_Id(userId))
                 .scrapCount(scrapRepository.countByUser_Id(userId))


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #73

## 📝 작업 내용

마이페이지에서 "방문한 지역 수"를 표시하기 위해 /api/v1/users/me 응답의 Stats에 districtCount 필드를 추가

**변경 사항**

신규 생성
- `PassportRepository.countDistinctDistrictByUserId()` — 유저의 고유 방문 지역 수 조회 쿼리

기존 파일 수정
- `MyProfileResponse.java` — Stats 내부 클래스에 `districtCount` 필드 추가
- `UserService.java` — getMyProfile(), updateMyProfile() Stats 빌더에 districtCount 추가

| 필드 | 의미 |
|------|------|
| passportCount | 전체 여권 페이지 수 (기록 수) |
| districtCount | 방문한 고유 지역 수 |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

