### PR TITLE
FEAT:  API 엔드포인트 경로 버그 수정 및 더미데이터 삽입

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -144,7 +144,7 @@ public class PassportController {
 
     @Operation(summary = "릴스형 여권 피드 조회",
             description = "다른 사용자의 PUBLIC 여권을 인기순으로 조회합니다. 카테고리/지역/위치 필터 지원, 커서 기반 무한스크롤.")
-    @GetMapping("/api/v1/feed")
+    @GetMapping("/feed")
     public ApiResponse<FeedCursorResponse<FeedPassportResponse>> getFeed(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "카테고리 필터") @RequestParam(required = false) Category category,
@@ -165,7 +165,7 @@ public class PassportController {
     @Operation(summary = "내 불빛 조회",
             description = "지도 화면에 표시할 본인 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
                     "모든 visibility 노출.")
-    @GetMapping("/api/v1/users/me/lights")
+    @GetMapping("/lights/me")
     public ApiResponse<List<LightResponse>> getMyLights(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
@@ -181,7 +181,7 @@ public class PassportController {
     @Operation(summary = "특정 사용자 불빛 조회",
             description = "지정된 사용자가 작성한 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
                     "PUBLIC 노출 + 친구 관계인 경우 FRIENDS_ONLY 포함.")
-    @GetMapping("/api/v1/users/{userId}/lights")
+    @GetMapping("/lights/{userId}")
     public ApiResponse<List<LightResponse>> getUserLights(
             @AuthenticationPrincipal Long viewerId,
             @Parameter(description = "조회 대상 사용자 ID") @PathVariable Long userId,

--- a/src/main/resources/db/seed/dummy_seed.sql
+++ b/src/main/resources/db/seed/dummy_seed.sql
@@ -1,0 +1,278 @@
+BEGIN;
+
+-- 재현 가능한 랜덤 시드
+SELECT setseed(0.42);
+
+
+INSERT INTO users (nickname, email, profile_img, friend_code, current_mode, location, bio, created_at, updated_at)
+SELECT
+    'dummy_user_' || LPAD(gs::text, 3, '0'),
+    'dummy' || gs || '@lightrip.dev',
+    'https://cdn.lightrip.cloud/profile-images/dummy/profile_' || gs || '.jpg',
+    'D' || LPAD(UPPER(TO_HEX(gs)), 7, '0'),
+    CASE WHEN gs % 5 = 0 THEN 'TEAM' ELSE 'INDIVIDUAL' END,
+    CASE (gs % 3)
+        WHEN 0 THEN '서울특별시'
+        WHEN 1 THEN '경기도'
+        ELSE '인천광역시'
+    END,
+    '안녕하세요! 더미 유저 ' || gs || '입니다.',
+    NOW() - (random() * INTERVAL '180 days'),
+    NOW()
+FROM generate_series(1, 300) AS gs;
+
+-- =============================================================================
+-- 2. FRIENDS (500건) - 70% ACCEPTED, 30% PENDING
+-- =============================================================================
+INSERT INTO friend (request_id, receiver_id, status, created_at)
+WITH dummy_users AS (
+    SELECT user_id
+    FROM users
+    WHERE nickname LIKE 'dummy_user_%'
+),
+pairs AS (
+    SELECT
+        a.user_id AS request_id,
+        b.user_id AS receiver_id,
+        random() AS r
+    FROM dummy_users a
+    CROSS JOIN dummy_users b
+    WHERE a.user_id < b.user_id
+    ORDER BY r
+    LIMIT 1500
+)
+SELECT
+    request_id,
+    receiver_id,
+    CASE WHEN random() < 0.7 THEN 'ACCEPTED' ELSE 'PENDING' END,
+    NOW() - (random() * INTERVAL '90 days')
+FROM pairs;
+
+-- =============================================================================
+-- 3. PASSPORTS (2000건) - 200명 × 평균 10건
+-- =============================================================================
+INSERT INTO passport (
+    user_id, content, latitude, longitude, address, visited_at,
+    district_category, category, visibility,
+    like_count, scrap_count, ai_category, space_name,
+    music_title, music_artist, created_at, updated_at
+)
+WITH dummy_users AS (
+    SELECT user_id, ROW_NUMBER() OVER (ORDER BY user_id) AS rn
+    FROM users
+    WHERE nickname LIKE 'dummy_user_%'
+),
+districts(arr) AS (VALUES (ARRAY[
+    'JONGNO','JUNG','YONGSAN','SEONGDONG','GWANGJIN','DONGDAEMUN',
+    'JUNGNANG','SEONGBUK','GANGBUK','DOBONG','NOWON','EUNPYEONG',
+    'SEODAEMUN','MAPO','YANGCHEON','GANGSEO','GURO','GEUMCHEON',
+    'YEONGDEUNGPO','DONGJAK','GWANAK','SEOCHO','GANGNAM','SONGPA','GANGDONG',
+    'SUWON','SEONGNAM','GOYANG','YONGIN','BUCHEON','ANSAN','ANYANG',
+    'NAMYANGJU','HWASEONG','PYEONGTAEK','UIJEONGBU','SIHEUNG','PAJU',
+    'GIMPO','GWANGMYEONG','GWANGJU_GG','GUNPO','HANAM','OSAN','ICHEON',
+    'YANGJU','ANSEONG','GURI','POCHEON','UIWANG','YEOJU','DONGDUCHEON',
+    'GAPYEONG','YANGPYEONG','YEONCHEON','GWACHEON'
+])),
+categories(arr) AS (VALUES (ARRAY[
+    'CAFE','RESTAURANT','BAR','CULTURE','ACTIVITY','SHOPPING','NATURE','ETC'
+])),
+visibilities(arr) AS (VALUES (ARRAY[
+    'PUBLIC','PUBLIC','PUBLIC','PUBLIC','PUBLIC','PUBLIC','PUBLIC',
+    'FRIENDS_ONLY','FRIENDS_ONLY','PRIVATE'
+]))
+SELECT
+    du.user_id,
+    '여기 정말 좋았어요! 다시 방문하고 싶은 곳입니다. (더미 여권 #' || gs || ')',
+    (37.4 + random() * 0.4)::numeric(10,7),
+    (126.8 + random() * 0.5)::numeric(10,7),
+    '서울특별시 더미구 더미로 ' || gs,
+    CURRENT_DATE - ((random() * 180)::int),
+    d.arr[1 + (random() * (array_length(d.arr, 1) - 1))::int],
+    c.arr[1 + (random() * (array_length(c.arr, 1) - 1))::int],
+    v.arr[1 + (random() * (array_length(v.arr, 1) - 1))::int],
+    (random() * 100)::bigint,
+    (random() * 30)::bigint,
+    c.arr[1 + (random() * (array_length(c.arr, 1) - 1))::int],
+    '더미 장소 #' || gs,
+    'Dummy Song #' || ((gs % 100) + 1),
+    'Dummy Artist #' || ((gs % 50) + 1),
+    NOW() - (random() * INTERVAL '180 days'),
+    NOW()
+FROM generate_series(1, 10000) AS gs
+CROSS JOIN districts d
+CROSS JOIN categories c
+CROSS JOIN visibilities v
+JOIN dummy_users du ON du.rn = ((gs - 1) % 300) + 1
+ON CONFLICT (user_id, latitude, longitude, visited_at) DO NOTHING;
+
+-- =============================================================================
+-- 4. PASSPORT_IMAGE (여권당 1~5장)
+-- =============================================================================
+INSERT INTO passport_image (passport_id, image_order, image_url, created_at)
+SELECT
+    p.passport_id,
+    img_order,
+    'https://cdn.lightrip.cloud/passport-images/dummy/' || p.passport_id || '_' || img_order || '.jpg',
+    p.created_at
+FROM passport p
+JOIN users u ON p.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%'
+CROSS JOIN LATERAL generate_series(1, 1 + (random() * 4)::int) AS img_order;
+
+-- =============================================================================
+-- 5. PASSPORT_STAMP (여권당 1~2개 카테고리)
+-- =============================================================================
+
+-- 5-1. 기본 스탬프: 여권의 main category 스탬프 1개
+INSERT INTO passport_stamp (passport_id, category, image_url, created_at)
+SELECT
+    p.passport_id,
+    p.category,
+    'https://cdn.lightrip.cloud/stamps/' || p.category || '.png',
+    p.created_at
+FROM passport p
+JOIN users u ON p.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%';
+
+-- 5-2. 추가 스탬프: 30% 여권에 보조 카테고리 1개 더
+INSERT INTO passport_stamp (passport_id, category, image_url, created_at)
+SELECT
+    p.passport_id,
+    c.extra_cat::varchar,
+    'https://cdn.lightrip.cloud/stamps/' || c.extra_cat || '.png',
+    p.created_at
+FROM passport p
+JOIN users u ON p.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%'
+CROSS JOIN LATERAL (
+    SELECT (ARRAY['CAFE','RESTAURANT','BAR','CULTURE','ACTIVITY','SHOPPING','NATURE','ETC'])
+           [1 + (random() * 7)::int] AS extra_cat
+) c
+WHERE random() < 0.3 AND c.extra_cat <> p.category::text
+ON CONFLICT (passport_id, category) DO NOTHING;
+
+-- =============================================================================
+-- 6. LIKES (~8000건) - 다른 유저가 PUBLIC 여권에 좋아요
+-- =============================================================================
+INSERT INTO likes (user_id, passport_id, created_at)
+SELECT
+    u.user_id,
+    p.passport_id,
+    NOW() - (random() * INTERVAL '60 days')
+FROM (
+    SELECT user_id
+    FROM users
+    WHERE nickname LIKE 'dummy_user_%'
+) u
+CROSS JOIN LATERAL (
+    SELECT passport_id
+    FROM passport pp
+    JOIN users pu ON pp.user_id = pu.user_id AND pu.nickname LIKE 'dummy_user_%'
+    WHERE pp.visibility = 'PUBLIC' AND pp.user_id <> u.user_id
+    ORDER BY random()
+    LIMIT 60
+) p
+ON CONFLICT (user_id, passport_id) DO NOTHING;
+
+-- =============================================================================
+-- 7. SCRAP (~4000건) - 다른 유저가 PUBLIC 여권 스크랩
+-- =============================================================================
+INSERT INTO scrap (user_id, passport_id, created_at)
+SELECT
+    u.user_id,
+    p.passport_id,
+    NOW() - (random() * INTERVAL '60 days')
+FROM (
+    SELECT user_id
+    FROM users
+    WHERE nickname LIKE 'dummy_user_%'
+) u
+CROSS JOIN LATERAL (
+    SELECT passport_id
+    FROM passport pp
+    JOIN users pu ON pp.user_id = pu.user_id AND pu.nickname LIKE 'dummy_user_%'
+    WHERE pp.visibility = 'PUBLIC' AND pp.user_id <> u.user_id
+    ORDER BY random()
+    LIMIT 30
+) p
+ON CONFLICT (user_id, passport_id) DO NOTHING;
+
+-- =============================================================================
+-- 8. like_count / scrap_count 동기화
+-- =============================================================================
+UPDATE passport p
+SET like_count = COALESCE(l.cnt, 0)
+FROM (
+    SELECT passport_id, COUNT(*)::bigint AS cnt
+    FROM likes
+    GROUP BY passport_id
+) l
+WHERE p.passport_id = l.passport_id;
+
+UPDATE passport p
+SET scrap_count = COALESCE(s.cnt, 0)
+FROM (
+    SELECT passport_id, COUNT(*)::bigint AS cnt
+    FROM scrap
+    GROUP BY passport_id
+) s
+WHERE p.passport_id = s.passport_id;
+
+-- =============================================================================
+-- 9. DISTRICT_COVER (유저별 지역 대표 이미지)
+--    각 (user, district)별 가장 최근 여권의 첫 이미지를 cover 로 지정
+-- =============================================================================
+INSERT INTO district_cover (user_id, district_category, passport_image_id, created_at, updated_at)
+SELECT DISTINCT ON (p.user_id, p.district_category)
+    p.user_id,
+    p.district_category,
+    pi.passport_image_id,
+    NOW(),
+    NOW()
+FROM passport p
+JOIN passport_image pi ON pi.passport_id = p.passport_id AND pi.image_order = 1
+JOIN users u ON p.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%'
+ORDER BY p.user_id, p.district_category, p.created_at DESC
+ON CONFLICT (user_id, district_category) DO NOTHING;
+
+-- =============================================================================
+-- 결과 요약
+-- =============================================================================
+DO $$
+DECLARE
+    user_cnt    bigint;
+    friend_cnt  bigint;
+    passport_cnt bigint;
+    image_cnt   bigint;
+    stamp_cnt   bigint;
+    like_cnt    bigint;
+    scrap_cnt   bigint;
+    cover_cnt   bigint;
+BEGIN
+    SELECT COUNT(*) INTO user_cnt FROM users WHERE nickname LIKE 'dummy_user_%';
+    SELECT COUNT(*) INTO friend_cnt FROM friend f
+        JOIN users u1 ON f.request_id = u1.user_id AND u1.nickname LIKE 'dummy_user_%';
+    SELECT COUNT(*) INTO passport_cnt FROM passport p
+        JOIN users u ON p.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%';
+    SELECT COUNT(*) INTO image_cnt FROM passport_image pi
+        JOIN passport p ON pi.passport_id = p.passport_id
+        JOIN users u ON p.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%';
+    SELECT COUNT(*) INTO stamp_cnt FROM passport_stamp ps
+        JOIN passport p ON ps.passport_id = p.passport_id
+        JOIN users u ON p.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%';
+    SELECT COUNT(*) INTO like_cnt FROM likes l
+        JOIN users u ON l.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%';
+    SELECT COUNT(*) INTO scrap_cnt FROM scrap s
+        JOIN users u ON s.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%';
+    SELECT COUNT(*) INTO cover_cnt FROM district_cover dc
+        JOIN users u ON dc.user_id = u.user_id AND u.nickname LIKE 'dummy_user_%';
+
+    RAISE NOTICE '=== LighTrip 더미 데이터 삽입 결과 ===';
+    RAISE NOTICE 'users          : %', user_cnt;
+    RAISE NOTICE 'friend         : %', friend_cnt;
+    RAISE NOTICE 'passport       : %', passport_cnt;
+    RAISE NOTICE 'passport_image : %', image_cnt;
+    RAISE NOTICE 'passport_stamp : %', stamp_cnt;
+    RAISE NOTICE 'likes          : %', like_cnt;
+    RAISE NOTICE 'scrap          : %', scrap_cnt;
+    RAISE NOTICE 'district_cover : %', cover_cnt;
+END $$;
+
+COMMIT;

--- a/src/main/resources/db/seed/dummy_seed_rollback.sql
+++ b/src/main/resources/db/seed/dummy_seed_rollback.sql
@@ -1,0 +1,92 @@
+-- =============================================================================
+-- LighTrip 더미 데이터 롤백 (Issue #78)
+-- 목적     : dummy_seed.sql 로 삽입한 데이터 전체 제거
+-- 식별자   : nickname LIKE 'dummy_user_%' 인 유저 + 그에 연결된 모든 데이터
+-- 안전성   : 트랜잭션 + ON_ERROR_STOP 으로 실패 시 전체 롤백
+-- 실행 방법:
+--   psql -h <RDS_HOST> -U <USER> -d <DB> -v ON_ERROR_STOP=1 -f dummy_seed_rollback.sql
+--
+-- ⚠️ prod 환경에서 실행 시 사고 위험 — 반드시 RDS snapshot 후 실행
+-- =============================================================================
+
+BEGIN;
+
+-- 삭제 전 카운트 출력
+DO $$
+DECLARE
+    user_cnt bigint;
+BEGIN
+    SELECT COUNT(*) INTO user_cnt FROM users WHERE nickname LIKE 'dummy_user_%';
+    RAISE NOTICE '롤백 대상 더미 유저 수: %', user_cnt;
+END $$;
+
+-- 자식 → 부모 순으로 삭제 (FK 제약 위반 방지)
+
+-- 1. district_cover
+DELETE FROM district_cover
+WHERE user_id IN (SELECT user_id FROM users WHERE nickname LIKE 'dummy_user_%');
+
+-- 2. scrap
+DELETE FROM scrap
+WHERE user_id IN (SELECT user_id FROM users WHERE nickname LIKE 'dummy_user_%')
+   OR passport_id IN (
+       SELECT p.passport_id
+       FROM passport p
+       JOIN users u ON p.user_id = u.user_id
+       WHERE u.nickname LIKE 'dummy_user_%'
+   );
+
+-- 3. likes
+DELETE FROM likes
+WHERE user_id IN (SELECT user_id FROM users WHERE nickname LIKE 'dummy_user_%')
+   OR passport_id IN (
+       SELECT p.passport_id
+       FROM passport p
+       JOIN users u ON p.user_id = u.user_id
+       WHERE u.nickname LIKE 'dummy_user_%'
+   );
+
+-- 4. passport_stamp
+DELETE FROM passport_stamp
+WHERE passport_id IN (
+    SELECT p.passport_id
+    FROM passport p
+    JOIN users u ON p.user_id = u.user_id
+    WHERE u.nickname LIKE 'dummy_user_%'
+);
+
+-- 5. passport_image
+DELETE FROM passport_image
+WHERE passport_id IN (
+    SELECT p.passport_id
+    FROM passport p
+    JOIN users u ON p.user_id = u.user_id
+    WHERE u.nickname LIKE 'dummy_user_%'
+);
+
+-- 6. passport
+DELETE FROM passport
+WHERE user_id IN (SELECT user_id FROM users WHERE nickname LIKE 'dummy_user_%');
+
+-- 7. friend
+DELETE FROM friend
+WHERE request_id IN (SELECT user_id FROM users WHERE nickname LIKE 'dummy_user_%')
+   OR receiver_id IN (SELECT user_id FROM users WHERE nickname LIKE 'dummy_user_%');
+
+-- 8. users
+DELETE FROM users WHERE nickname LIKE 'dummy_user_%';
+
+-- 결과 확인
+DO $$
+DECLARE
+    remaining bigint;
+BEGIN
+    SELECT COUNT(*) INTO remaining FROM users WHERE nickname LIKE 'dummy_user_%';
+    IF remaining = 0 THEN
+        RAISE NOTICE '✅ 모든 더미 데이터 삭제 완료';
+    ELSE
+        RAISE EXCEPTION '❌ 더미 유저 % 명이 남아 있음 - 롤백', remaining;
+    END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #79

## 📝 작업 내용

### 1. PassportController 엔드포인트 경로 버그 수정
`@RequestMapping("/api/v1/passports")` 클래스 레벨 prefix와 메서드 레벨 경로의 `/api/v1` 중복으로 잘못된 URL이 노출되던 3개 엔드포인트를 수정

| 이전 (중복) | 이후 |
|---|---|
| `/api/v1/passports/api/v1/feed` | `/api/v1/passports/feed` |
| `/api/v1/passports/api/v1/users/me/lights` | `/api/v1/passports/lights/me` |
| `/api/v1/passports/api/v1/users/{userId}/lights` | `/api/v1/passports/lights/{userId}` |

### 2. 더미 데이터 시드 SQL 추가
랭킹 집계 / 친구 추천 / 피드 등 주요 기능 검증을 위한 시드/롤백 SQL 작성. `nickname LIKE 'dummy_user_%'` 패턴으로 식별 가능해 안전하게 롤백 가능합니다.

- `src/main/resources/db/seed/dummy_seed.sql`
- `src/main/resources/db/seed/dummy_seed_rollback.sql`

**삽입 데이터 (트랜잭션 단위):**
| 테이블 | 건수 |
|---|---|
| users | 300 |
| friend | 1,500 (70% ACCEPTED / 30% PENDING) |
| passport | 10,000 (visibility 70/20/10) |
| passport_image | 30,000 |
| passport_stamp | 12,614 |
| likes | 18,000 |
| scrap | 9,000 |
| district_cover | 7,541 |

- `setseed(0.42)` 으로 재현 가능한 랜덤 결과
- `BEGIN/COMMIT` 트랜잭션 + `ON CONFLICT DO NOTHING` 으로 안전성 확보
- 좋아요/스크랩 카운트는 실제 집계로 동기화

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다. (RDS에 시드 실행 → 카운트 검증 완료)