### PR TITLE
FEAT: 여권 커버 텍스트색상 컬럼 추가 및 API 생성

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,6 @@
+FROM postgis/postgis:17-3.5
+
+# pgvector 설치 (PostGIS 공식 이미지가 Debian 기반이라 apt로 가능)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends postgresql-17-pgvector \
+ && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   db:
-    image: ankane/pgvector:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.db
     environment:
       POSTGRES_DB: lightrip
       POSTGRES_USER: ${DB_USERNAME}

--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -101,7 +101,7 @@ public class FriendController {
 
         List<FriendPassportResponse> response =
                 friendService.getFriendPassports(userId, friendId, pageable);
-        return ApiResponse.success(response);
+        return ApiResponse.success(response); 
     }
 
     @Operation(summary = "친구 지도 조회", description = "친구의 공개(PUBLIC) 여권 기준으로 방문한 지역 목록을 조회합니다. ACCEPTED 상태의 친구만 조회 가능합니다.")

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -187,18 +187,17 @@ public class FriendService {
 
         List<Object[]> counts = passportRepository.countPublicByUserIdGroupByDistrict(friendId);
 
-        Map<District, String> coverMap = districtCoverRepository.findAllByUser_Id(friendId).stream()
-                .collect(Collectors.toMap(
-                        DistrictCover::getDistrictCategory,
-                        cover -> cover.getPassportImage().getImageUrl()
-                ));
+        Map<District, DistrictCover> coverMap = districtCoverRepository.findAllByUser_Id(friendId).stream()
+                .collect(Collectors.toMap(DistrictCover::getDistrictCategory, c -> c));
 
         return counts.stream()
                 .map(row -> {
                     District district = (District) row[0];
                     Long count = (Long) row[1];
-                    String thumbnailUrl = coverMap.get(district);
-                    return DistrictResponse.of(district, count, thumbnailUrl);
+                    DistrictCover cover = coverMap.get(district);
+                    String thumbnailUrl = cover != null ? cover.getPassportImage().getImageUrl() : null;
+                    String textColor = cover != null ? cover.getTextColor() : null;
+                    return DistrictResponse.of(district, count, thumbnailUrl, textColor);
                 })
                 .toList();
     }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/DistrictCoverController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/DistrictCoverController.java
@@ -1,0 +1,33 @@
+package com.kauniv.lightrip.domain.passport.controller;
+
+import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverTextColorRequest;
+import com.kauniv.lightrip.domain.passport.service.DistrictCoverService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "DistrictCover", description = "지역 커버 API")
+@RestController
+@RequestMapping("/api/v1/district-covers")
+@RequiredArgsConstructor
+public class DistrictCoverController {
+
+    private final DistrictCoverService districtCoverService;
+
+    @Operation(summary = "지역 커버 텍스트 색상 변경",
+            description = "커버 이미지 위에 표시되는 지역명 텍스트 색상을 HEX 코드로 변경합니다. 본인 소유 커버만 변경 가능합니다.")
+    @PatchMapping("/{coverId}/text-color")
+    public ApiResponse<Void> updateTextColor(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "지역 커버 ID") @PathVariable Long coverId,
+            @Valid @RequestBody DistrictCoverTextColorRequest request
+    ) {
+        districtCoverService.updateTextColor(userId, coverId, request);
+        return ApiResponse.success("텍스트 색상이 변경되었습니다.", null);
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/DistrictCoverTextColorRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/DistrictCoverTextColorRequest.java
@@ -1,0 +1,17 @@
+package com.kauniv.lightrip.domain.passport.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "지역 커버 텍스트 색상 변경 요청")
+public record DistrictCoverTextColorRequest(
+
+        @Schema(description = "HEX 색상 코드 (#RRGGBB 6자리)", example = "#FFFFFF")
+        @NotBlank(message = "텍스트 색상은 필수입니다.")
+        @Pattern(
+                regexp = "^#[A-Fa-f0-9]{6}$",
+                message = "색상은 #RRGGBB 형식의 HEX 코드여야 합니다."
+        )
+        String textColor
+) {}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/DistrictResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/DistrictResponse.java
@@ -17,14 +17,18 @@ public record DistrictResponse(
         Long passportCount,
 
         @Schema(description = "대표 이미지 URL")
-        String thumbnailUrl
+        String thumbnailUrl,
+
+        @Schema(description = "지역명 텍스트 색상 (HEX #RRGGBB)", example = "#FFFFFF")
+        String textColor
 ) {
-    public static DistrictResponse of(District district, Long count, String thumbnailUrl) {
+    public static DistrictResponse of(District district, Long count, String thumbnailUrl, String textColor) {
         return new DistrictResponse(
                 district,
                 district.getDisplayName(),
                 count,
-                thumbnailUrl
+                thumbnailUrl,
+                textColor
         );
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/DistrictCover.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/DistrictCover.java
@@ -46,6 +46,12 @@ public class DistrictCover {
     @Column(name = "district_category", nullable = false)
     private District districtCategory;
 
+    @Column(name = "text_color", nullable = false, length = 7)
+    @Builder.Default
+    private String textColor = "#FFFFFF";
+    // > 커버 이미지 위에 표시되는 지역명 텍스트 색상 (HEX #RRGGBB).
+    // > 기본값 흰색. PATCH API로 사용자가 변경.
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -56,5 +62,9 @@ public class DistrictCover {
 
     public void changeCoverImage(PassportImage newImage) {
         this.passportImage = newImage;
+    }
+
+    public void changeTextColor(String textColor) {
+        this.textColor = textColor;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
@@ -1,0 +1,30 @@
+package com.kauniv.lightrip.domain.passport.service;
+
+import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverTextColorRequest;
+import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
+import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DistrictCoverService {
+
+    private final DistrictCoverRepository districtCoverRepository;
+
+    @Transactional
+    public void updateTextColor(Long userId, Long coverId, DistrictCoverTextColorRequest req) {
+        DistrictCover cover = districtCoverRepository.findById(coverId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DISTRICT_COVER_NOT_FOUND));
+
+        if (!cover.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.DISTRICT_COVER_FORBIDDEN);
+        }
+
+        cover.changeTextColor(req.textColor());
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -227,13 +227,16 @@ public class PassportService {
     // ========== 내 기록 지역 조회 ==========
     public List<DistrictResponse> getMyDistricts(Long userId) {
         List<Object[]> counts = passportRepository.countByUserIdGroupByDistrict(userId);
-        Map<District, String> coverMap = districtCoverRepository.findAllByUser_Id(userId).stream()
-                .collect(Collectors.toMap(
-                        DistrictCover::getDistrictCategory,
-                        cover -> cover.getPassportImage().getImageUrl()
-                ));
+        Map<District, DistrictCover> coverMap = districtCoverRepository.findAllByUser_Id(userId).stream()
+                .collect(Collectors.toMap(DistrictCover::getDistrictCategory, c -> c));
         return counts.stream()
-                .map(row -> DistrictResponse.of((District) row[0], (Long) row[1], coverMap.get((District) row[0])))
+                .map(row -> {
+                    District district = (District) row[0];
+                    DistrictCover cover = coverMap.get(district);
+                    String thumbnailUrl = cover != null ? cover.getPassportImage().getImageUrl() : null;
+                    String textColor = cover != null ? cover.getTextColor() : null;
+                    return DistrictResponse.of(district, (Long) row[1], thumbnailUrl, textColor);
+                })
                 .toList();
     }
 

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/response/MyProfileResponse.java
@@ -1,6 +1,5 @@
 package com.kauniv.lightrip.domain.user.dto.response;
 
-import com.kauniv.lightrip.domain.user.entity.CurrentMode;
 import com.kauniv.lightrip.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +17,8 @@ public class MyProfileResponse {
     private String friendCode;
     private String location;
     private String bio;
-    private CurrentMode currentMode;
+    private String themeColor;
+    private String passportTheme;
     private LocalDateTime createdAt;
     private Stats stats;
 
@@ -41,7 +41,8 @@ public class MyProfileResponse {
                 .friendCode(user.getFriendCode())
                 .location(user.getLocation())
                 .bio(user.getBio())
-                .currentMode(user.getCurrentMode())
+                .themeColor(user.getThemeColor())
+                .passportTheme(user.getPassportTheme())
                 .createdAt(user.getCreatedAt())
                 .stats(stats)
                 .build();

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/CurrentMode.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/CurrentMode.java
@@ -1,6 +1,0 @@
-package com.kauniv.lightrip.domain.user.entity;
-
-public enum CurrentMode {
-    INDIVIDUAL, // 개인 모드
-    TEAM // 팀 모드
-}

--- a/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/entity/User.java
@@ -33,15 +33,20 @@ public class User {
     @Column(name = "friend_code", nullable = false, unique = true, length = 8)
     private String friendCode;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "current_mode")
-    private CurrentMode currentMode;
-
     @Column(name = "location", length = 100)
     private String location;
 
     @Column(name = "bio", columnDefinition = "TEXT")
     private String bio;
+
+    @Column(name = "theme_color", nullable = false, length = 7)
+    @Builder.Default
+    private String themeColor = "#FFFFFF";
+    // > 프로필 테마 색상 (HEX #RRGGBB). 기본 흰색.
+
+    @Column(name = "passport_theme", columnDefinition = "TEXT")
+    private String passportTheme;
+    // > 여권 테마 (테마 이름 또는 이미지 URL). nullable.
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
@@ -68,5 +73,13 @@ public class User {
         this.profileImg = profileImg;
         this.location = location;
         this.bio = bio;
+    }
+
+    public void changeThemeColor(String themeColor) {
+        this.themeColor = themeColor;
+    }
+
+    public void changePassportTheme(String passportTheme) {
+        this.passportTheme = passportTheme;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -8,7 +8,6 @@ import com.kauniv.lightrip.domain.user.dto.response.MyProfileResponse;
 import com.kauniv.lightrip.domain.user.dto.response.PublicProfileResponse;
 import com.kauniv.lightrip.domain.user.dto.request.UpdateProfileRequest;
 import com.kauniv.lightrip.global.auth.entity.Auth;
-import com.kauniv.lightrip.domain.user.entity.CurrentMode;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.global.auth.repository.AuthRepository;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
@@ -47,7 +46,6 @@ public class UserService {
                 User.builder()
                         .nickname(oAuth2UserInfo.getNickname())
                         .email(oAuth2UserInfo.getEmail())
-                        .currentMode(CurrentMode.INDIVIDUAL)
                         .build()
         );
 

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -59,7 +59,11 @@ public enum ErrorCode {
 
     // ===== Ranking =====
     RANKING_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "랭킹 정보가 존재하지 않습니다."),
-    RANKING_CALCULATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R002", "랭킹 산정 중 오류가 발생했습니다.");
+    RANKING_CALCULATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R002", "랭킹 산정 중 오류가 발생했습니다."),
+
+    // ===== DistrictCover =====
+    DISTRICT_COVER_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "존재하지 않는 지역 커버입니다."),
+    DISTRICT_COVER_FORBIDDEN(HttpStatus.FORBIDDEN, "D002", "해당 지역 커버에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/db/migration/V3__add_district_cover_text_color.sql
+++ b/src/main/resources/db/migration/V3__add_district_cover_text_color.sql
@@ -1,0 +1,6 @@
+-- district_cover에 텍스트 색상(HEX) 컬럼 추가
+-- > 여권 커버 이미지 위에 표시되는 지역명 텍스트의 색상.
+-- > 프론트엔드 UI에서 #RRGGBB 형식 HEX 코드 문자열로 사용.
+-- > 기본값은 흰색(#FFFFFF). 기존 레코드는 DEFAULT로 자동 채워짐.
+ALTER TABLE public.district_cover
+    ADD COLUMN text_color VARCHAR(7) NOT NULL DEFAULT '#FFFFFF';

--- a/src/main/resources/db/migration/V4__user_theme_columns.sql
+++ b/src/main/resources/db/migration/V4__user_theme_columns.sql
@@ -1,0 +1,12 @@
+-- users 테이블에서 current_mode 컬럼 제거 + 테마 관련 컬럼 추가
+-- > current_mode: 더 이상 사용하지 않는 사용자 상태(INDIVIDUAL/TEAM) 컬럼 제거.
+-- > theme_color: 프로필 테마 색상 (HEX #RRGGBB). 기본값 흰색.
+-- > passport_theme: 여권 테마. 테마 이름 또는 이미지 URL 등 자유 문자열. nullable.
+
+ALTER TABLE public.users DROP COLUMN IF EXISTS current_mode;
+
+ALTER TABLE public.users
+    ADD COLUMN theme_color VARCHAR(7) NOT NULL DEFAULT '#FFFFFF';
+
+ALTER TABLE public.users
+    ADD COLUMN passport_theme TEXT;

--- a/src/main/resources/db/seed/dummy_seed.sql
+++ b/src/main/resources/db/seed/dummy_seed.sql
@@ -4,13 +4,12 @@ BEGIN;
 SELECT setseed(0.42);
 
 
-INSERT INTO users (nickname, email, profile_img, friend_code, current_mode, location, bio, created_at, updated_at)
+INSERT INTO users (nickname, email, profile_img, friend_code, location, bio, created_at, updated_at)
 SELECT
     'dummy_user_' || LPAD(gs::text, 3, '0'),
     'dummy' || gs || '@lightrip.dev',
     'https://cdn.lightrip.cloud/profile-images/dummy/profile_' || gs || '.jpg',
     'D' || LPAD(UPPER(TO_HEX(gs)), 7, '0'),
-    CASE WHEN gs % 5 = 0 THEN 'TEAM' ELSE 'INDIVIDUAL' END,
     CASE (gs % 3)
         WHEN 0 THEN '서울특별시'
         WHEN 1 THEN '경기도'


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #81

## 📝 작업 내용

### 1. DistrictCover 텍스트 색상 기능 (이슈 #81)
- `DistrictCover`에 `text_color` 컬럼 추가 (HEX `#RRGGBB`, 기본 `#FFFFFF`)
- `PATCH /api/v1/district-covers/{coverId}/text-color` API 신규 추가
- HEX 형식 `@Pattern` 검증 + 본인 소유 권한 검사
- `DistrictResponse`에 `textColor` 필드 포함 (지역 조회 응답에 함께 반환)

### 2. User 엔티티 정리
- `theme_color`, `passport_theme` 컬럼 추가
- 사용처 없는 `current_mode` 컬럼/`CurrentMode` enum 제거

### 3. 로컬 개발 환경 fix
- `ankane/pgvector` → `Dockerfile.db`(PostGIS + pgvector) 로 교체
- 기존 이미지에 PostGIS가 없어 Flyway V1 실행이 막히던 문제 해결

### 마이그레이션
- `V3__add_district_cover_text_color.sql`
- `V4__user_theme_columns.sql`

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.