### PR TITLE
FEAT: 여권 커버 이미지 변경 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -195,7 +195,7 @@ public class FriendService {
                     District district = (District) row[0];
                     Long count = (Long) row[1];
                     DistrictCover cover = coverMap.get(district);
-                    String thumbnailUrl = cover != null ? cover.getPassportImage().getImageUrl() : null;
+                    String thumbnailUrl = cover != null ? cover.getImageUrl() : null;
                     String textColor = cover != null ? cover.getTextColor() : null;
                     return DistrictResponse.of(district, count, thumbnailUrl, textColor);
                 })

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/DistrictCoverController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/DistrictCoverController.java
@@ -1,5 +1,6 @@
 package com.kauniv.lightrip.domain.passport.controller;
 
+import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverImageRequest;
 import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverTextColorRequest;
 import com.kauniv.lightrip.domain.passport.service.DistrictCoverService;
 import com.kauniv.lightrip.global.common.response.ApiResponse;
@@ -29,5 +30,17 @@ public class DistrictCoverController {
     ) {
         districtCoverService.updateTextColor(userId, coverId, request);
         return ApiResponse.success("텍스트 색상이 변경되었습니다.", null);
+    }
+
+    @Operation(summary = "지역 커버 이미지 변경",
+            description = "지역 커버의 대표 이미지를 본인 여권 이미지 중 하나로 변경합니다. 본인 소유 커버 + 본인 여권 이미지만 허용됩니다.")
+    @PatchMapping("/{coverId}/image")
+    public ApiResponse<Void> updateCoverImage(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "지역 커버 ID") @PathVariable Long coverId,
+            @Valid @RequestBody DistrictCoverImageRequest request
+    ) {
+        districtCoverService.updateCoverImage(userId, coverId, request);
+        return ApiResponse.success("커버 이미지가 변경되었습니다.", null);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/DistrictCoverImageRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/DistrictCoverImageRequest.java
@@ -1,12 +1,14 @@
 package com.kauniv.lightrip.domain.passport.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "지역 커버 이미지 변경 요청")
 public record DistrictCoverImageRequest(
 
-        @Schema(description = "새 커버로 지정할 여권 이미지 ID", example = "42")
-        @NotNull(message = "여권 이미지 ID는 필수입니다.")
-        Long passportImageId
+        @Schema(description = "새 커버 이미지 URL", example = "https://cdn.lightrip.cloud/passports/1/abc.jpg")
+        @NotBlank(message = "이미지 URL은 필수입니다.")
+        @Size(max = 2048, message = "이미지 URL은 2048자를 넘을 수 없습니다.")
+        String imageUrl
 ) {}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/DistrictCoverImageRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/DistrictCoverImageRequest.java
@@ -1,0 +1,12 @@
+package com.kauniv.lightrip.domain.passport.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "지역 커버 이미지 변경 요청")
+public record DistrictCoverImageRequest(
+
+        @Schema(description = "새 커버로 지정할 여권 이미지 ID", example = "42")
+        @NotNull(message = "여권 이미지 ID는 필수입니다.")
+        Long passportImageId
+) {}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/DistrictCover.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/DistrictCover.java
@@ -38,9 +38,9 @@ public class DistrictCover {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "passport_image_id", nullable = false)
-    private PassportImage passportImage;
+    @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
+    private String imageUrl;
+    // > 커버 대표 이미지 URL. 여권 이미지 URL을 복사하거나, 사용자가 자유롭게 외부 URL로 변경 가능.
 
     @Enumerated(EnumType.STRING)
     @Column(name = "district_category", nullable = false)
@@ -60,8 +60,8 @@ public class DistrictCover {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public void changeCoverImage(PassportImage newImage) {
-        this.passportImage = newImage;
+    public void changeCoverImage(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     public void changeTextColor(String textColor) {

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
@@ -3,9 +3,7 @@ package com.kauniv.lightrip.domain.passport.service;
 import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverImageRequest;
 import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverTextColorRequest;
 import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
-import com.kauniv.lightrip.domain.passport.entity.PassportImage;
 import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
-import com.kauniv.lightrip.domain.passport.repository.PassportImageRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class DistrictCoverService {
 
     private final DistrictCoverRepository districtCoverRepository;
-    private final PassportImageRepository passportImageRepository;
 
     @Transactional
     public void updateTextColor(Long userId, Long coverId, DistrictCoverTextColorRequest req) {
@@ -41,14 +38,6 @@ public class DistrictCoverService {
             throw new BusinessException(ErrorCode.DISTRICT_COVER_FORBIDDEN);
         }
 
-        PassportImage image = passportImageRepository.findById(req.passportImageId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_IMAGE_NOT_FOUND));
-
-        if (!image.getPassport().getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.PASSPORT_IMAGE_FORBIDDEN);
-        }
-        // > Loose 검증: 본인 여권의 이미지면 OK. district 일치 여부는 검사하지 않음.
-
-        cover.changeCoverImage(image);
+        cover.changeCoverImage(req.imageUrl());
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
@@ -1,8 +1,11 @@
 package com.kauniv.lightrip.domain.passport.service;
 
+import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverImageRequest;
 import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverTextColorRequest;
 import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
+import com.kauniv.lightrip.domain.passport.entity.PassportImage;
 import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
+import com.kauniv.lightrip.domain.passport.repository.PassportImageRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DistrictCoverService {
 
     private final DistrictCoverRepository districtCoverRepository;
+    private final PassportImageRepository passportImageRepository;
 
     @Transactional
     public void updateTextColor(Long userId, Long coverId, DistrictCoverTextColorRequest req) {
@@ -26,5 +30,25 @@ public class DistrictCoverService {
         }
 
         cover.changeTextColor(req.textColor());
+    }
+
+    @Transactional
+    public void updateCoverImage(Long userId, Long coverId, DistrictCoverImageRequest req) {
+        DistrictCover cover = districtCoverRepository.findById(coverId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DISTRICT_COVER_NOT_FOUND));
+
+        if (!cover.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.DISTRICT_COVER_FORBIDDEN);
+        }
+
+        PassportImage image = passportImageRepository.findById(req.passportImageId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_IMAGE_NOT_FOUND));
+
+        if (!image.getPassport().getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.PASSPORT_IMAGE_FORBIDDEN);
+        }
+        // > Loose 검증: 본인 여권의 이미지면 OK. district 일치 여부는 검사하지 않음.
+
+        cover.changeCoverImage(image);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -168,10 +168,10 @@ public class PassportService {
     private void createDistrictCoverIfFirst(User user, Passport passport) {
         District district = passport.getDistrictCategory();
         if (!districtCoverRepository.existsByUser_IdAndDistrictCategory(user.getId(), district)) {
-            PassportImage firstImage = passport.getImages().get(0);
+            String firstImageUrl = passport.getImages().get(0).getImageUrl();
             DistrictCover cover = DistrictCover.builder()
                     .user(user)
-                    .passportImage(firstImage)
+                    .imageUrl(firstImageUrl)
                     .districtCategory(district)
                     .build();
             districtCoverRepository.save(cover);
@@ -186,7 +186,7 @@ public class PassportService {
                             .ifPresentOrElse(
                                     latestPassport -> {
                                         if (!latestPassport.getImages().isEmpty()) {
-                                            cover.changeCoverImage(latestPassport.getImages().get(0));
+                                            cover.changeCoverImage(latestPassport.getImages().get(0).getImageUrl());
                                         }
                                     },
                                     () -> districtCoverRepository.delete(cover)
@@ -233,7 +233,7 @@ public class PassportService {
                 .map(row -> {
                     District district = (District) row[0];
                     DistrictCover cover = coverMap.get(district);
-                    String thumbnailUrl = cover != null ? cover.getPassportImage().getImageUrl() : null;
+                    String thumbnailUrl = cover != null ? cover.getImageUrl() : null;
                     String textColor = cover != null ? cover.getTextColor() : null;
                     return DistrictResponse.of(district, (Long) row[1], thumbnailUrl, textColor);
                 })

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -29,8 +29,6 @@ public enum ErrorCode {
     PASSPORT_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "해당 여권에 대한 권한이 없습니다."),
     PASSPORT_DUPLICATE(HttpStatus.CONFLICT, "P003", "같은 장소, 같은 날짜에 이미 등록된 여권이 있습니다."),
     PASSPORT_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "P004", "방문 인증에 실패했습니다."),
-    PASSPORT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "P005", "존재하지 않는 여권 이미지입니다."),
-    PASSPORT_IMAGE_FORBIDDEN(HttpStatus.FORBIDDEN, "P006", "해당 여권 이미지에 대한 권한이 없습니다."),
 
     // ===== Scrap =====
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "스크랩 기록이 존재하지 않습니다."),

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     PASSPORT_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "해당 여권에 대한 권한이 없습니다."),
     PASSPORT_DUPLICATE(HttpStatus.CONFLICT, "P003", "같은 장소, 같은 날짜에 이미 등록된 여권이 있습니다."),
     PASSPORT_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "P004", "방문 인증에 실패했습니다."),
+    PASSPORT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "P005", "존재하지 않는 여권 이미지입니다."),
+    PASSPORT_IMAGE_FORBIDDEN(HttpStatus.FORBIDDEN, "P006", "해당 여권 이미지에 대한 권한이 없습니다."),
 
     // ===== Scrap =====
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "스크랩 기록이 존재하지 않습니다."),

--- a/src/main/resources/db/migration/V5__district_cover_image_url.sql
+++ b/src/main/resources/db/migration/V5__district_cover_image_url.sql
@@ -1,0 +1,21 @@
+-- district_cover에서 passport_image_id 외래키를 제거하고 image_url을 직접 저장하도록 전환
+-- > 변경 이유: 사용자가 여권 이미지 외에도 자유로운 이미지 URL을 커버로 지정할 수 있도록 유연성 확보.
+-- > 데이터 보존: 기존 passport_image_id가 가리키던 image_url을 backfill로 옮긴 뒤 컬럼 삭제.
+
+-- 1. 새 image_url 컬럼 추가 (일단 nullable로)
+ALTER TABLE public.district_cover
+    ADD COLUMN image_url TEXT;
+
+-- 2. 기존 passport_image_id 기반으로 image_url 채움
+UPDATE public.district_cover dc
+SET image_url = pi.image_url
+FROM public.passport_image pi
+WHERE dc.passport_image_id = pi.passport_image_id;
+
+-- 3. NOT NULL 제약 추가
+ALTER TABLE public.district_cover
+    ALTER COLUMN image_url SET NOT NULL;
+
+-- 4. 기존 passport_image_id 컬럼 + FK 제약 제거 (CASCADE로 의존 제약 자동 삭제)
+ALTER TABLE public.district_cover
+    DROP COLUMN passport_image_id;

--- a/src/main/resources/db/seed/dummy_seed.sql
+++ b/src/main/resources/db/seed/dummy_seed.sql
@@ -218,11 +218,11 @@ WHERE p.passport_id = s.passport_id;
 -- 9. DISTRICT_COVER (유저별 지역 대표 이미지)
 --    각 (user, district)별 가장 최근 여권의 첫 이미지를 cover 로 지정
 -- =============================================================================
-INSERT INTO district_cover (user_id, district_category, passport_image_id, created_at, updated_at)
+INSERT INTO district_cover (user_id, district_category, image_url, created_at, updated_at)
 SELECT DISTINCT ON (p.user_id, p.district_category)
     p.user_id,
     p.district_category,
-    pi.passport_image_id,
+    pi.image_url,
     NOW(),
     NOW()
 FROM passport p


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #85

## 📝 작업 내용

### 1. 여권 커버 이미지 변경 API 추가
- `PATCH /api/v1/district-covers/{coverId}/image` 신규 엔드포인트
- 본인 소유 커버만 변경 가능 (`@Pattern` 대신 단순 `@NotBlank` + 길이 제한)
- 요청 바디: `{ "imageUrl": "https://..." }`

### 2. 저장 방식 전환: `passport_image_id` FK → `image_url` 직접 저장
- 사용자가 여권 이미지뿐 아니라 자유로운 URL을 커버로 지정할 수 있도록 유연성 확보
- 조회 시 JOIN 제거 → 연산 부담 감소
- 외부 URL 입력 허용 (loose 검증)


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.