### PR TITLE
FEAT: 내 팀 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/controller/TeamController.java
@@ -34,6 +34,15 @@ public class TeamController {
                 .body(teamService.create(userId, req));
     }
 
+    // 현재 로그인한 유저의 소속 팀을 반환한다.
+    // 팀 모드 전환 시 프론트엔드가 teamId를 얻기 위해 호출하며, 미소속 시 404를 반환한다.
+    @Operation(summary = "내 팀 조회", description = "현재 로그인한 유저가 소속된 팀 정보를 반환합니다. 팀 미소속 시 404를 반환합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<TeamResponse> getMyTeam(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(teamService.getMyTeam(userId));
+    }
+
     @Operation(summary = "팀 코드로 검색", description = "팀 코드로 팀을 검색합니다. 가입 전 팀 정보를 미리 확인할 때 사용합니다.")
     @GetMapping("/search")
     public ResponseEntity<TeamResponse> searchByCode(

--- a/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
@@ -15,4 +15,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByTeam_IdAndUser_Id(Long teamId, Long userId);
 
     Optional<TeamMember> findByTeam_IdAndRole(Long teamId, TeamMember.Role role);
+
+    // 유저가 속한 팀 조회 (유저당 팀 1개)
+    Optional<TeamMember> findByUser_Id(Long userId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -83,6 +83,14 @@ public class TeamService {
         return TeamResponse.from(team);
     }
 
+    // 현재 유저가 소속된 팀을 반환한다. 유저당 팀 1개 제약이 있으므로 단일 결과를 반환하며,
+    // 소속 팀이 없으면 TEAM_NOT_JOINED 예외를 던진다.
+    public TeamResponse getMyTeam(Long userId) {
+        TeamMember member = teamMemberRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_JOINED));
+        return TeamResponse.from(member.getTeam());
+    }
+
     public TeamResponse getTeam(Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     TEAM_NOT_MEMBER(HttpStatus.FORBIDDEN, "T004", "팀 멤버가 아닙니다."),
     TEAM_LEADER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "T005", "팀장은 팀을 탈퇴할 수 없습니다."),
     TEAM_FULL(HttpStatus.CONFLICT, "T006", "팀 인원이 가득 찼습니다."),
+    TEAM_NOT_JOINED(HttpStatus.NOT_FOUND, "T007", "소속된 팀이 없습니다."),
 
     // ===== Map =====
     REVERSE_GEOCODE_FAILED(HttpStatus.BAD_GATEWAY, "M001", "역지오코딩에 실패했습니다."),

--- a/src/main/resources/db/migration/V5__drop_team_invite_code.sql
+++ b/src/main/resources/db/migration/V5__drop_team_invite_code.sql
@@ -1,0 +1,2 @@
+-- V1에서 미사용 컬럼으로 생성된 invite_code 제거
+ALTER TABLE public.team DROP COLUMN invite_code;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #83

## 📝 작업 내용

- [x] `GET /api/v1/teams/me` 엔드포인트 추가
- [x] `TeamMemberRepository`에 `findByUser_Id()` 쿼리 메서드 추가
- [x] `TeamService`에 `getMyTeam()` 서비스 로직 추가
- [x] `ErrorCode`에 `TEAM_NOT_JOINED(T007)` 추가
- [x] V5 마이그레이션으로 `team` 테이블의 미사용 `invite_code` 컬럼 제거 (팀 생성 오류 수정)

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

