### PR TITLE
FEAT: 카카오 회원가입 후 온보딩 프로필 설정 API 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/controller/TeamController.java
@@ -34,15 +34,6 @@ public class TeamController {
                 .body(teamService.create(userId, req));
     }
 
-    // 현재 로그인한 유저의 소속 팀을 반환한다.
-    // 팀 모드 전환 시 프론트엔드가 teamId를 얻기 위해 호출하며, 미소속 시 404를 반환한다.
-    @Operation(summary = "내 팀 조회", description = "현재 로그인한 유저가 소속된 팀 정보를 반환합니다. 팀 미소속 시 404를 반환합니다.")
-    @GetMapping("/me")
-    public ResponseEntity<TeamResponse> getMyTeam(
-            @AuthenticationPrincipal Long userId) {
-        return ResponseEntity.ok(teamService.getMyTeam(userId));
-    }
-
     @Operation(summary = "팀 코드로 검색", description = "팀 코드로 팀을 검색합니다. 가입 전 팀 정보를 미리 확인할 때 사용합니다.")
     @GetMapping("/search")
     public ResponseEntity<TeamResponse> searchByCode(

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -83,14 +83,6 @@ public class TeamService {
         return TeamResponse.from(team);
     }
 
-    // 현재 유저가 소속된 팀을 반환한다. 유저당 팀 1개 제약이 있으므로 단일 결과를 반환하며,
-    // 소속 팀이 없으면 TEAM_NOT_JOINED 예외를 던진다.
-    public TeamResponse getMyTeam(Long userId) {
-        TeamMember member = teamMemberRepository.findByUser_Id(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_JOINED));
-        return TeamResponse.from(member.getTeam());
-    }
-
     public TeamResponse getTeam(Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));

--- a/src/main/java/com/kauniv/lightrip/domain/user/controller/UserController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.kauniv.lightrip.domain.user.controller;
 
+import com.kauniv.lightrip.domain.user.dto.request.CompleteProfileRequest;
 import com.kauniv.lightrip.domain.user.dto.request.UpdateProfileRequest;
 import com.kauniv.lightrip.domain.user.dto.response.MyProfileResponse;
 import com.kauniv.lightrip.domain.user.dto.response.PublicProfileResponse;
@@ -25,6 +26,14 @@ public class UserController {
     public ApiResponse<MyProfileResponse> getMyProfile(
             @AuthenticationPrincipal Long userId) {
         return ApiResponse.success(userService.getMyProfile(userId));
+    }
+
+    @Operation(summary = "온보딩 프로필 설정", description = "카카오 회원가입 후 닉네임, 활동 지역, 한 줄 소개를 초기 설정합니다.")
+    @PatchMapping("/me/onboarding")
+    public ApiResponse<MyProfileResponse> completeOnboarding(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody CompleteProfileRequest request) {
+        return ApiResponse.success(userService.completeOnboarding(userId, request));
     }
 
     @Operation(summary = "내 프로필 편집", description = "닉네임과 프로필 이미지를 수정합니다.")

--- a/src/main/java/com/kauniv/lightrip/domain/user/dto/request/CompleteProfileRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/dto/request/CompleteProfileRequest.java
@@ -1,0 +1,19 @@
+package com.kauniv.lightrip.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class CompleteProfileRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
+    private String nickname;
+
+    @Size(max = 100, message = "활동 지역은 100자 이하여야 합니다.")
+    private String location;
+
+    @Size(max = 200, message = "한 줄 소개는 200자 이하여야 합니다.")
+    private String bio;
+}

--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.kauniv.lightrip.domain.friend.repository.FriendRepository;
 import com.kauniv.lightrip.domain.like.repository.LikeRepository;
 import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
 import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
+import com.kauniv.lightrip.domain.user.dto.request.CompleteProfileRequest;
 import com.kauniv.lightrip.domain.user.dto.response.MyProfileResponse;
 import com.kauniv.lightrip.domain.user.dto.response.PublicProfileResponse;
 import com.kauniv.lightrip.domain.user.dto.request.UpdateProfileRequest;
@@ -85,6 +86,30 @@ public class UserService {
         }
 
         user.updateProfile(request.getNickname(), request.getProfileImg(), request.getLocation(), request.getBio());
+
+        MyProfileResponse.Stats stats = MyProfileResponse.Stats.builder()
+                .passportCount(passportRepository.countByUser_Id(userId))
+                .districtCount(passportRepository.countDistinctDistrictByUserId(userId))
+                .friendCount(friendRepository.findAllFriends(userId).size())
+                .likeCount(likeRepository.countByUser_Id(userId))
+                .scrapCount(scrapRepository.countByUser_Id(userId))
+                .build();
+
+        return MyProfileResponse.from(user, stats);
+    }
+
+    @Transactional
+    public MyProfileResponse completeOnboarding(Long userId, CompleteProfileRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.getNickname().equals(request.getNickname())
+                && userRepository.existsByNickname(request.getNickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        // profileImg는 온보딩 화면에서 다루지 않으므로 기존 값 유지
+        user.updateProfile(request.getNickname(), user.getProfileImg(), request.getLocation(), request.getBio());
 
         MyProfileResponse.Stats stats = MyProfileResponse.Stats.builder()
                 .passportCount(passportRepository.countByUser_Id(userId))


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #89

## 📝 작업 내용

> 카카오 로그인 후 isNewUser=true인 신규 사용자가 닉네임, 활동 지역, 한 줄 소개를 초기 설정하는 온보딩 API 추가
> 내 팀 조회 API는 lights/me?teamId로 대체되어 제거

### 신규 생성

- CompleteProfileRequest.java — 온보딩 요청 DTO (닉네임 max 10, 활동지역, 한줄소개)

### 기존 파일 수정

- UserController.java — PATCH /api/v1/users/me/onboarding 엔드포인트 추가
- UserService.java — completeOnboarding() 메서드 추가
- TeamController.java — GET /api/v1/teams/me 제거 (lights/me?teamId로 대체)
- TeamService.java — getMyTeam() 메서드 제거

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

