### PR TITLE
FEAT: 특정 지역의 내 여권 상세 정보 보기 API 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -180,6 +180,29 @@ public class PassportController {
         return ApiResponse.success(passportService.getMyPassports(userId, category, null, cursor, size));
     }
 
+    @Operation(summary = "지역별 내 여권 상세 조회",
+            description = """
+                    특정 지역(districtCategory)의 내 여권 상세 정보를 커서 기반으로 페이징 조회합니다.
+
+                    - 정렬: 방문일(visitedAt) 내림차순, 동일 시 ID 내림차순
+                    - 페이지 크기: 기본 10
+                    - 응답: 여권 상세 전체 필드 (이미지/본문/좌표/음악/도장 등 `PassportResponse`)
+                    - 첫 요청: `cursor` 생략, 다음 페이지: 이전 응답의 `nextCursor` 사용
+                    - 잘못된 districtCategory 값 입력 시 400을 반환합니다.
+                    """)
+    @GetMapping("/districts/{districtCategory}")
+    public ApiResponse<CursorResponse<PassportResponse>> getMyPassportDetailsByDistrict(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "지역 카테고리 (MAPO, GANGNAM, YONGSAN 등)")
+            @PathVariable District districtCategory,
+            @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 페이지에 가져올 여권 수 (기본값: 10)") @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.success(
+                passportService.getMyPassportDetailsByDistrict(userId, districtCategory, cursor, size)
+        );
+    }
+
     @Operation(summary = "릴스형 여권 피드 조회",
             description = "다른 사용자의 PUBLIC 여권을 인기순으로 조회합니다. 카테고리/지역/위치 필터 지원, 커서 기반 무한스크롤.")
     @GetMapping("/feed")

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -253,6 +253,19 @@ public class PassportService {
         return CursorResponse.of(passports.stream().map(PassportListResponse::from).toList(), hasNext, nextCursor);
     }
 
+    // ========== 지역별 내 여권 상세 목록 조회 ==========
+    public CursorResponse<PassportResponse> getMyPassportDetailsByDistrict(Long userId,
+                                                                          District districtCategory,
+                                                                          Long cursor, int size) {
+        List<Passport> passports = (cursor == null)
+                ? passportRepository.findMyPassportsFirst(userId, null, districtCategory, PageRequest.of(0, size + 1))
+                : passportRepository.findMyPassportsAfterCursor(userId, cursor, null, districtCategory, PageRequest.of(0, size + 1));
+        boolean hasNext = passports.size() > size;
+        if (hasNext) passports = passports.subList(0, size);
+        Long nextCursor = hasNext ? passports.get(passports.size() - 1).getId() : null;
+        return CursorResponse.of(passports.stream().map(PassportResponse::from).toList(), hasNext, nextCursor);
+    }
+
     // ========== 내 여권 통계 조회 ==========
     public PassportStatsResponse getMyStats(Long userId) {
         return new PassportStatsResponse(


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
> Closes #95

## 📝 작업 내용

> 지역(districtCategory) 단위로 내 여권을 **상세 전체 필드**(이미지/본문/좌표/음악/도장 등)와 함께 커서 기반으로 페이징해서 조회하는 API 추가
> 기존 `/me`, `/categories/{category}`는 요약 응답(`PassportListResponse`)만 제공하므로, 지역별 상세 화면을 위한 별도 엔드포인트가 필요했음


### 기존 파일 수정

- PassportController.java — `GET /api/v1/passports/districts/{districtCategory}` 엔드포인트 추가 + Swagger 문서
- PassportService.java — `getMyPassportDetailsByDistrict()` 메서드 추가 (기존 `findMyPassportsFirst` / `findMyPassportsAfterCursor`에 `category=null`로 전달, 응답은 `PassportResponse`로 매핑)

## ℹ️ 동작 명세

- **정렬**: `visitedAt DESC → id DESC` (기존 `/me` 조회와 동일)
- **페이지 크기**: `size` 기본 10, 커서 기반 무한스크롤 (`cursor` = 이전 응답의 `nextCursor`)
- **응답**: `CursorResponse<PassportResponse>` — 이미지/본문/좌표/음악/도장(stampUrls)/likeCount/scrapCount 등 상세 전체
- **인증/공개범위**: 본인 여권만 조회, 모든 `visibility`(PUBLIC/FRIENDS_ONLY/PRIVATE) 포함
- **에러**: 잘못된 `districtCategory` enum 값 → 400 (`GlobalExceptionHandler`의 enum 변환 핸들러로 친절 메시지)

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.