### PR TITLE
FEAT: 지도 불빛 API 클러스터링 및 LightController 분리

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
@@ -34,10 +34,10 @@ public class LightController {
     @GetMapping("/me")
     public ApiResponse<List<LightResponse>> getMyLights(
             @AuthenticationPrincipal Long userId,
-            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
-            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
-            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
-            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng,
+            @Parameter(description = "남쪽 경계 위도") @RequestParam BigDecimal minLat,
+            @Parameter(description = "북쪽 경계 위도") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "서쪽 경계 경도") @RequestParam BigDecimal minLng,
+            @Parameter(description = "동쪽 경계 경도") @RequestParam BigDecimal maxLng,
             @Parameter(description = "팀 ID (선택) — 지정 시 해당 팀 여권 조회") @RequestParam(required = false) Long teamId
     ) {
         return ApiResponse.success(
@@ -56,10 +56,10 @@ public class LightController {
     public ApiResponse<List<LightResponse>> getUserLights(
             @AuthenticationPrincipal Long viewerId,
             @Parameter(description = "조회 대상 사용자 ID") @PathVariable Long userId,
-            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
-            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
-            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
-            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng
+            @Parameter(description = "남쪽 경계 위도") @RequestParam BigDecimal minLat,
+            @Parameter(description = "북쪽 경계 위도") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "서쪽 경계 경도") @RequestParam BigDecimal minLng,
+            @Parameter(description = "동쪽 경계 경도") @RequestParam BigDecimal maxLng
     ) {
         return ApiResponse.success(
                 passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng)
@@ -78,10 +78,10 @@ public class LightController {
     @GetMapping("/cluster")
     public ApiResponse<CursorResponse<PassportListResponse>> getLightCluster(
             @AuthenticationPrincipal Long userId,
-            @Parameter(description = "최소 위도 (셀 좌하단)") @RequestParam BigDecimal minLat,
-            @Parameter(description = "최대 위도 (셀 우상단)") @RequestParam BigDecimal maxLat,
-            @Parameter(description = "최소 경도 (셀 좌하단)") @RequestParam BigDecimal minLng,
-            @Parameter(description = "최대 경도 (셀 우상단)") @RequestParam BigDecimal maxLng,
+            @Parameter(description = "남쪽 경계 위도") @RequestParam BigDecimal minLat,
+            @Parameter(description = "북쪽 경계 위도") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "서쪽 경계 경도") @RequestParam BigDecimal minLng,
+            @Parameter(description = "동쪽 경계 경도") @RequestParam BigDecimal maxLng,
             @Parameter(description = "팀 ID (선택) — 지정 시 팀 여권 조회") @RequestParam(required = false) Long teamId,
             @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
             @Parameter(description = "한 페이지에 가져올 여권 수 (기본 10)") @RequestParam(defaultValue = "10") int size

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
@@ -1,0 +1,58 @@
+package com.kauniv.lightrip.domain.passport.controller;
+
+import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
+import com.kauniv.lightrip.domain.passport.service.PassportService;
+import com.kauniv.lightrip.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Tag(name = "Map", description = "지도 불빛 API")
+@RestController
+@RequestMapping("/api/v1/lights")
+@RequiredArgsConstructor
+public class LightController {
+
+    private final PassportService passportService;
+
+    @Operation(summary = "내 불빛 조회",
+            description = "지도 화면에 표시할 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
+                    "teamId 미지정 시 본인 여권(모든 visibility) 조회, " +
+                    "teamId 지정 시 해당 팀 여권(visibility 무시) 조회 — 팀 멤버만 허용.")
+    @GetMapping("/me")
+    public ApiResponse<List<LightResponse>> getMyLights(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
+            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
+            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng,
+            @Parameter(description = "팀 ID (선택) — 지정 시 해당 팀 여권 조회") @RequestParam(required = false) Long teamId
+    ) {
+        return ApiResponse.success(
+                passportService.getMyLights(userId, minLat, maxLat, minLng, maxLng, teamId)
+        );
+    }
+
+    @Operation(summary = "특정 사용자 불빛 조회",
+            description = "지정된 사용자가 작성한 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
+                    "PUBLIC 노출 + 친구 관계인 경우 FRIENDS_ONLY 포함.")
+    @GetMapping("/{userId}")
+    public ApiResponse<List<LightResponse>> getUserLights(
+            @AuthenticationPrincipal Long viewerId,
+            @Parameter(description = "조회 대상 사용자 ID") @PathVariable Long userId,
+            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
+            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
+            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng
+    ) {
+        return ApiResponse.success(
+                passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng)
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
@@ -22,9 +22,15 @@ public class LightController {
     private final PassportService passportService;
 
     @Operation(summary = "내 불빛 조회",
-            description = "지도 화면에 표시할 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
-                    "teamId 미지정 시 본인 여권(모든 visibility) 조회, " +
-                    "teamId 지정 시 해당 팀 여권(visibility 무시) 조회 — 팀 멤버만 허용.")
+            description = """
+                    지도 화면에 표시할 여권 좌표를 Bounding Box 범위 내에서 조회합니다.
+
+                    - `teamId` 미지정: 본인 여권(모든 visibility) 조회
+                    - `teamId` 지정: 해당 팀 여권(visibility 무시) — 팀 멤버만 허용
+                    - `zoom` 16 이상: 기존 개별 좌표 응답
+                    - `zoom` 16 미만: 격자 단위 클러스터링 응답 (`isCluster=true`, `count`, `centerLatitude/Longitude`)
+                    - 셀 내 여권이 1개면 단일 응답으로 반환 (`isCluster=false`, ID·디테일 포함)
+                    """)
     @GetMapping("/me")
     public ApiResponse<List<LightResponse>> getMyLights(
             @AuthenticationPrincipal Long userId,
@@ -32,16 +38,23 @@ public class LightController {
             @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
             @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
             @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng,
+            @Parameter(description = "지도 줌 레벨 (0~22). 16 이상이면 개별 좌표, 미만이면 클러스터링. 기본 16")
+            @RequestParam(defaultValue = "16") int zoom,
             @Parameter(description = "팀 ID (선택) — 지정 시 해당 팀 여권 조회") @RequestParam(required = false) Long teamId
     ) {
         return ApiResponse.success(
-                passportService.getMyLights(userId, minLat, maxLat, minLng, maxLng, teamId)
+                passportService.getMyLights(userId, minLat, maxLat, minLng, maxLng, zoom, teamId)
         );
     }
 
     @Operation(summary = "특정 사용자 불빛 조회",
-            description = "지정된 사용자가 작성한 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
-                    "PUBLIC 노출 + 친구 관계인 경우 FRIENDS_ONLY 포함.")
+            description = """
+                    지정된 사용자가 작성한 여권 좌표를 Bounding Box 범위 내에서 조회합니다.
+
+                    - PUBLIC 노출 + 친구 관계인 경우 FRIENDS_ONLY 포함
+                    - `zoom` 16 이상: 기존 개별 좌표 응답
+                    - `zoom` 16 미만: 격자 단위 클러스터링 응답
+                    """)
     @GetMapping("/{userId}")
     public ApiResponse<List<LightResponse>> getUserLights(
             @AuthenticationPrincipal Long viewerId,
@@ -49,10 +62,12 @@ public class LightController {
             @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
             @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
             @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
-            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng
+            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng,
+            @Parameter(description = "지도 줌 레벨 (0~22). 16 이상이면 개별 좌표, 미만이면 클러스터링. 기본 16")
+            @RequestParam(defaultValue = "16") int zoom
     ) {
         return ApiResponse.success(
-                passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng)
+                passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng, zoom)
         );
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/LightController.java
@@ -1,8 +1,10 @@
 package com.kauniv.lightrip.domain.passport.controller;
 
 import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
+import com.kauniv.lightrip.domain.passport.dto.response.PassportListResponse;
 import com.kauniv.lightrip.domain.passport.service.PassportService;
 import com.kauniv.lightrip.global.common.response.ApiResponse;
+import com.kauniv.lightrip.global.common.response.CursorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,9 +29,7 @@ public class LightController {
 
                     - `teamId` 미지정: 본인 여권(모든 visibility) 조회
                     - `teamId` 지정: 해당 팀 여권(visibility 무시) — 팀 멤버만 허용
-                    - `zoom` 16 이상: 기존 개별 좌표 응답
-                    - `zoom` 16 미만: 격자 단위 클러스터링 응답 (`isCluster=true`, `count`, `centerLatitude/Longitude`)
-                    - 셀 내 여권이 1개면 단일 응답으로 반환 (`isCluster=false`, ID·디테일 포함)
+                    - BBox 폭에 비례한 격자로 자동 클러스터링되며, 셀 내 여권이 1개면 단일 응답(`isCluster=false`, ID·디테일 포함), 2개 이상이면 클러스터 응답(`isCluster=true`, `count`, `centerLatitude/Longitude`)
                     """)
     @GetMapping("/me")
     public ApiResponse<List<LightResponse>> getMyLights(
@@ -38,12 +38,10 @@ public class LightController {
             @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
             @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
             @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng,
-            @Parameter(description = "지도 줌 레벨 (0~22). 16 이상이면 개별 좌표, 미만이면 클러스터링. 기본 16")
-            @RequestParam(defaultValue = "16") int zoom,
             @Parameter(description = "팀 ID (선택) — 지정 시 해당 팀 여권 조회") @RequestParam(required = false) Long teamId
     ) {
         return ApiResponse.success(
-                passportService.getMyLights(userId, minLat, maxLat, minLng, maxLng, zoom, teamId)
+                passportService.getMyLights(userId, minLat, maxLat, minLng, maxLng, teamId)
         );
     }
 
@@ -52,8 +50,7 @@ public class LightController {
                     지정된 사용자가 작성한 여권 좌표를 Bounding Box 범위 내에서 조회합니다.
 
                     - PUBLIC 노출 + 친구 관계인 경우 FRIENDS_ONLY 포함
-                    - `zoom` 16 이상: 기존 개별 좌표 응답
-                    - `zoom` 16 미만: 격자 단위 클러스터링 응답
+                    - BBox 폭에 비례한 격자로 자동 클러스터링
                     """)
     @GetMapping("/{userId}")
     public ApiResponse<List<LightResponse>> getUserLights(
@@ -62,12 +59,35 @@ public class LightController {
             @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
             @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
             @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
-            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng,
-            @Parameter(description = "지도 줌 레벨 (0~22). 16 이상이면 개별 좌표, 미만이면 클러스터링. 기본 16")
-            @RequestParam(defaultValue = "16") int zoom
+            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng
     ) {
         return ApiResponse.success(
-                passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng, zoom)
+                passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng)
+        );
+    }
+
+    @Operation(summary = "클러스터 셀 상세 리스트",
+            description = """
+                    지도에서 클러스터를 클릭했을 때, 해당 셀의 BBox에 포함되는 여권 목록을 페이징 조회합니다.
+
+                    - `teamId` 미지정: 본인 여권만 (모든 visibility)
+                    - `teamId` 지정: 해당 팀 여권 (팀 멤버만, visibility 무시)
+                    - 페이징: 커서 기반, 정렬은 방문일 DESC → ID DESC
+                    - 첫 요청: `cursor` 생략, 다음 페이지: 이전 응답의 `nextCursor` 사용
+                    """)
+    @GetMapping("/cluster")
+    public ApiResponse<CursorResponse<PassportListResponse>> getLightCluster(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "최소 위도 (셀 좌하단)") @RequestParam BigDecimal minLat,
+            @Parameter(description = "최대 위도 (셀 우상단)") @RequestParam BigDecimal maxLat,
+            @Parameter(description = "최소 경도 (셀 좌하단)") @RequestParam BigDecimal minLng,
+            @Parameter(description = "최대 경도 (셀 우상단)") @RequestParam BigDecimal maxLng,
+            @Parameter(description = "팀 ID (선택) — 지정 시 팀 여권 조회") @RequestParam(required = false) Long teamId,
+            @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 페이지에 가져올 여권 수 (기본 10)") @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.success(
+                passportService.getLightCluster(userId, minLat, maxLat, minLng, maxLng, teamId, cursor, size)
         );
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -23,7 +23,6 @@ import com.kauniv.lightrip.global.enums.District;
 import com.kauniv.lightrip.domain.passport.dto.response.FeedPassportResponse;
 import com.kauniv.lightrip.global.common.response.FeedCursorResponse;
 import java.math.BigDecimal;
-import com.kauniv.lightrip.domain.passport.dto.response.LightResponse;
 
 @Tag(name = "Passport", description = "여권 API")
 @RestController
@@ -197,41 +196,6 @@ public class PassportController {
         return ApiResponse.success(
                 passportService.getFeed(userId, category, district, latitude, longitude,
                         radius, cursor, cursorScore, size)
-        );
-    }
-
-    @Operation(summary = "내 불빛 조회",
-            description = "지도 화면에 표시할 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
-                    "teamId 미지정 시 본인 여권(모든 visibility) 조회, " +
-                    "teamId 지정 시 해당 팀 여권(visibility 무시) 조회 — 팀 멤버만 허용.")
-    @GetMapping("/lights/me")
-    public ApiResponse<List<LightResponse>> getMyLights(
-            @AuthenticationPrincipal Long userId,
-            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
-            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
-            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
-            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng,
-            @Parameter(description = "팀 ID (선택) — 지정 시 해당 팀 여권 조회") @RequestParam(required = false) Long teamId
-    ) {
-        return ApiResponse.success(
-                passportService.getMyLights(userId, minLat, maxLat, minLng, maxLng, teamId)
-        );
-    }
-
-    @Operation(summary = "특정 사용자 불빛 조회",
-            description = "지정된 사용자가 작성한 여권 좌표를 Bounding Box 범위 내에서 조회합니다. " +
-                    "PUBLIC 노출 + 친구 관계인 경우 FRIENDS_ONLY 포함.")
-    @GetMapping("/lights/{userId}")
-    public ApiResponse<List<LightResponse>> getUserLights(
-            @AuthenticationPrincipal Long viewerId,
-            @Parameter(description = "조회 대상 사용자 ID") @PathVariable Long userId,
-            @Parameter(description = "최소 위도 (좌하단)") @RequestParam BigDecimal minLat,
-            @Parameter(description = "최대 위도 (우상단)") @RequestParam BigDecimal maxLat,
-            @Parameter(description = "최소 경도 (좌하단)") @RequestParam BigDecimal minLng,
-            @Parameter(description = "최대 경도 (우상단)") @RequestParam BigDecimal maxLng
-    ) {
-        return ApiResponse.success(
-                passportService.getUserLights(viewerId, userId, minLat, maxLat, minLng, maxLng)
         );
     }
 

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/LightResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/LightResponse.java
@@ -8,38 +8,50 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-@Schema(description = "지도 불빛 좌표 응답")
+@Schema(description = "지도 불빛 좌표 응답 (단일 여권 또는 클러스터)")
 public record LightResponse(
 
-        @Schema(description = "여권 ID")
+        @Schema(description = "여권 ID (클러스터인 경우 null)")
         Long passportId,
 
-        @Schema(description = "위도")
+        @Schema(description = "위도 (클러스터인 경우 null)")
         BigDecimal latitude,
 
-        @Schema(description = "경도")
+        @Schema(description = "경도 (클러스터인 경우 null)")
         BigDecimal longitude,
 
-        @Schema(description = "카테고리")
+        @Schema(description = "카테고리 (클러스터인 경우 null)")
         Category category,
 
-        @Schema(description = "지역 카테고리")
+        @Schema(description = "지역 카테고리 (클러스터인 경우 null)")
         District districtCategory,
 
-        @Schema(description = "위치명")
+        @Schema(description = "위치명 (클러스터인 경우 null)")
         String spaceName,
 
-        @Schema(description = "대표 이미지 URL (썸네일)")
+        @Schema(description = "대표 이미지 URL (썸네일, 클러스터인 경우 null)")
         String thumbnailUrl,
 
-        @Schema(description = "방문 날짜")
+        @Schema(description = "방문 날짜 (클러스터인 경우 null)")
         LocalDate visitedAt,
 
-        @Schema(description = "좋아요 수")
+        @Schema(description = "좋아요 수 (클러스터인 경우 null)")
         Long likeCount,
 
-        @Schema(description = "스크랩 수")
-        Long scrapCount
+        @Schema(description = "스크랩 수 (클러스터인 경우 null)")
+        Long scrapCount,
+
+        @Schema(description = "클러스터 여부 (true면 묶인 셀, false면 단일 여권)")
+        boolean isCluster,
+
+        @Schema(description = "셀 내 여권 수 (단일이면 1)")
+        long count,
+
+        @Schema(description = "셀 대표 위도 (단일이면 해당 여권 좌표와 동일)")
+        BigDecimal centerLatitude,
+
+        @Schema(description = "셀 대표 경도 (단일이면 해당 여권 좌표와 동일)")
+        BigDecimal centerLongitude
 ) {
     public static LightResponse from(Passport p) {
         String thumbnail = p.getImages().isEmpty()
@@ -56,7 +68,21 @@ public record LightResponse(
                 thumbnail,
                 p.getVisitedAt(),
                 p.getLikeCount(),
-                p.getScrapCount()
+                p.getScrapCount(),
+                false,
+                1L,
+                p.getLatitude(),
+                p.getLongitude()
+        );
+    }
+
+    public static LightResponse cluster(long count, BigDecimal centerLatitude, BigDecimal centerLongitude) {
+        return new LightResponse(
+                null, null, null, null, null, null, null, null, null, null,
+                true,
+                count,
+                centerLatitude,
+                centerLongitude
         );
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -166,6 +166,60 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     );
     // > 팀 여권만 (team_id 필터). visibility 무시 — 팀 내부면 PRIVATE도 노출 (B-1 정책).
 
+    @Query(value = """
+        SELECT
+            COUNT(*) AS cnt,
+            AVG(p.latitude) AS center_lat,
+            AVG(p.longitude) AS center_lng,
+            CASE WHEN COUNT(*) = 1 THEN MIN(p.passport_id) END AS single_id
+        FROM passport p
+        WHERE p.user_id = :targetUserId
+          AND ST_Within(
+              p.location,
+              ST_MakeEnvelope(CAST(:minLng AS float), CAST(:minLat AS float),
+                              CAST(:maxLng AS float), CAST(:maxLat AS float), 4326)
+          )
+          AND p.visibility IN (:visibilities)
+        GROUP BY ST_SnapToGrid(p.location, CAST(:cellSize AS float), CAST(:cellSize AS float))
+        """, nativeQuery = true)
+    List<Object[]> findUserLightClusters(
+            @Param("targetUserId") Long targetUserId,
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLng") BigDecimal minLng,
+            @Param("maxLng") BigDecimal maxLng,
+            @Param("visibilities") List<String> visibilities,
+            @Param("cellSize") double cellSize
+    );
+    // > ST_SnapToGrid로 location을 cellSize 격자에 스냅 → GROUP BY로 같은 셀끼리 묶음.
+    // > 셀 내 1건이면 single_id에 passport_id 보존 (서비스에서 단일 응답으로 매핑).
+    // > 반환: [cnt(BIGINT), center_lat(numeric), center_lng(numeric), single_id(BIGINT or null)]
+
+    @Query(value = """
+        SELECT
+            COUNT(*) AS cnt,
+            AVG(p.latitude) AS center_lat,
+            AVG(p.longitude) AS center_lng,
+            CASE WHEN COUNT(*) = 1 THEN MIN(p.passport_id) END AS single_id
+        FROM passport p
+        WHERE p.team_id = :teamId
+          AND ST_Within(
+              p.location,
+              ST_MakeEnvelope(CAST(:minLng AS float), CAST(:minLat AS float),
+                              CAST(:maxLng AS float), CAST(:maxLat AS float), 4326)
+          )
+        GROUP BY ST_SnapToGrid(p.location, CAST(:cellSize AS float), CAST(:cellSize AS float))
+        """, nativeQuery = true)
+    List<Object[]> findTeamLightClusters(
+            @Param("teamId") Long teamId,
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLng") BigDecimal minLng,
+            @Param("maxLng") BigDecimal maxLng,
+            @Param("cellSize") double cellSize
+    );
+    // > 팀 여권용 클러스터링 (visibility 무시).
+
     @Query("""
         SELECT p FROM Passport p
         LEFT JOIN FETCH p.images

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.springframework.data.jpa.repository.Query;
 import com.kauniv.lightrip.global.enums.Category;
+import com.kauniv.lightrip.global.enums.Visibility;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
@@ -124,49 +125,6 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     List<Passport> findAllByIdsForFeed(List<Long> ids);
 
     @Query(value = """
-        SELECT DISTINCT p.*
-        FROM passport p
-        WHERE p.user_id = :targetUserId
-          AND ST_Within(
-              p.location,
-              ST_MakeEnvelope(CAST(:minLng AS float), CAST(:minLat AS float),
-                              CAST(:maxLng AS float), CAST(:maxLat AS float), 4326)
-          )
-          AND p.visibility IN (:visibilities)
-        """, nativeQuery = true)
-    List<Passport> findLightsInBounds(
-            @Param("targetUserId") Long targetUserId,
-            @Param("minLat") BigDecimal minLat,
-            @Param("maxLat") BigDecimal maxLat,
-            @Param("minLng") BigDecimal minLng,
-            @Param("maxLng") BigDecimal maxLng,
-            @Param("visibilities") List<String> visibilities
-    );
-    // > ST_Within: 포인트가 사각형 영역 안에 있는지 확인.
-    // > ST_MakeEnvelope: bounding box 생성 (minLng, minLat, maxLng, maxLat).
-    // > GiST 인덱스 활용으로 기존 BETWEEN 대비 성능 개선.
-    // > visibilities는 List<String>으로 받아서 네이티브 쿼리 IN절에 전달.
-
-    @Query(value = """
-        SELECT DISTINCT p.*
-        FROM passport p
-        WHERE p.team_id = :teamId
-          AND ST_Within(
-              p.location,
-              ST_MakeEnvelope(CAST(:minLng AS float), CAST(:minLat AS float),
-                              CAST(:maxLng AS float), CAST(:maxLat AS float), 4326)
-          )
-        """, nativeQuery = true)
-    List<Passport> findTeamLightsInBounds(
-            @Param("teamId") Long teamId,
-            @Param("minLat") BigDecimal minLat,
-            @Param("maxLat") BigDecimal maxLat,
-            @Param("minLng") BigDecimal minLng,
-            @Param("maxLng") BigDecimal maxLng
-    );
-    // > 팀 여권만 (team_id 필터). visibility 무시 — 팀 내부면 PRIVATE도 노출 (B-1 정책).
-
-    @Query(value = """
         SELECT
             COUNT(*) AS cnt,
             AVG(p.latitude) AS center_lat,
@@ -219,6 +177,48 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
             @Param("cellSize") double cellSize
     );
     // > 팀 여권용 클러스터링 (visibility 무시).
+
+    @Query("""
+        SELECT p FROM Passport p
+        LEFT JOIN FETCH p.images
+        WHERE p.user.id = :userId
+          AND p.visibility IN :visibilities
+          AND p.latitude BETWEEN :minLat AND :maxLat
+          AND p.longitude BETWEEN :minLng AND :maxLng
+          AND (:cursor IS NULL OR p.id < :cursor)
+        ORDER BY p.visitedAt DESC, p.id DESC
+        """)
+    List<Passport> findUserPassportsInBounds(
+            @Param("userId") Long userId,
+            @Param("visibilities") List<Visibility> visibilities,
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLng") BigDecimal minLng,
+            @Param("maxLng") BigDecimal maxLng,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+    // > 클러스터 셀 BBox 안의 여권을 visibility 필터링 후 커서 페이징.
+
+    @Query("""
+        SELECT p FROM Passport p
+        LEFT JOIN FETCH p.images
+        WHERE p.team.id = :teamId
+          AND p.latitude BETWEEN :minLat AND :maxLat
+          AND p.longitude BETWEEN :minLng AND :maxLng
+          AND (:cursor IS NULL OR p.id < :cursor)
+        ORDER BY p.visitedAt DESC, p.id DESC
+        """)
+    List<Passport> findTeamPassportsInBounds(
+            @Param("teamId") Long teamId,
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLng") BigDecimal minLng,
+            @Param("maxLng") BigDecimal maxLng,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+    // > 팀 여권용 클러스터 셀 BBox 페이징 (visibility 무시).
 
     @Query("""
         SELECT p FROM Passport p

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -340,11 +340,11 @@ public class PassportService {
 
     // ========== 내 불빛 조회 ==========
     public List<LightResponse> getMyLights(Long userId, BigDecimal minLat, BigDecimal maxLat,
-                                           BigDecimal minLng, BigDecimal maxLng, int zoom, Long teamId) {
+                                           BigDecimal minLng, BigDecimal maxLng, Long teamId) {
         validateBoundingBox(minLat, maxLat, minLng, maxLng);
-        Double cellSize = cellSizeForZoom(zoom);
+        double cellSize = cellSizeForBBox(minLng, maxLng);
 
-        // > teamId가 있으면 팀 모드: 팀 멤버십 검증 후 팀 여권만 BBox 조회. visibility 무시.
+        // > teamId가 있으면 팀 모드: 팀 멤버십 검증 후 팀 여권만 클러스터링. visibility 무시.
         if (teamId != null) {
             if (!teamRepository.existsById(teamId)) {
                 throw new BusinessException(ErrorCode.TEAM_NOT_FOUND);
@@ -352,23 +352,14 @@ public class PassportService {
             if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
                 throw new BusinessException(ErrorCode.TEAM_NOT_MEMBER);
             }
-            if (cellSize == null) {
-                return passportRepository.findTeamLightsInBounds(teamId, minLat, maxLat, minLng, maxLng)
-                        .stream().map(LightResponse::from).toList();
-            }
             return mapClusterRows(passportRepository.findTeamLightClusters(
                     teamId, minLat, maxLat, minLng, maxLng, cellSize));
         }
 
-        // > teamId 없으면 개인 모드: 본인 여권 전체 visibility 조회.
+        // > teamId 없으면 개인 모드: 본인 여권 전체 visibility 클러스터링.
         List<Visibility> allowed = List.of(
                 Visibility.PUBLIC, Visibility.PRIVATE, Visibility.FRIENDS_ONLY
         );
-        if (cellSize == null) {
-            return passportRepository.findLightsInBounds(userId, minLat, maxLat, minLng, maxLng,
-                            toStringList(allowed))
-                    .stream().map(LightResponse::from).toList();
-        }
         return mapClusterRows(passportRepository.findUserLightClusters(
                 userId, minLat, maxLat, minLng, maxLng, toStringList(allowed), cellSize));
     }
@@ -376,10 +367,10 @@ public class PassportService {
     // ========== 특정 사용자 불빛 조회 ==========
     public List<LightResponse> getUserLights(Long viewerId, Long targetUserId,
                                              BigDecimal minLat, BigDecimal maxLat,
-                                             BigDecimal minLng, BigDecimal maxLng, int zoom) {
+                                             BigDecimal minLng, BigDecimal maxLng) {
         validateBoundingBox(minLat, maxLat, minLng, maxLng);
         if (viewerId.equals(targetUserId)) {
-            return getMyLights(viewerId, minLat, maxLat, minLng, maxLng, zoom, null);
+            return getMyLights(viewerId, minLat, maxLat, minLng, maxLng, null);
         }
         if (!userRepository.existsById(targetUserId)) throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         boolean isFriend = friendRepository.isFriend(viewerId, targetUserId);
@@ -387,24 +378,16 @@ public class PassportService {
                 ? List.of(Visibility.PUBLIC, Visibility.FRIENDS_ONLY)
                 : List.of(Visibility.PUBLIC);
 
-        Double cellSize = cellSizeForZoom(zoom);
-        if (cellSize == null) {
-            return passportRepository.findLightsInBounds(targetUserId, minLat, maxLat, minLng, maxLng,
-                            toStringList(allowed))
-                    .stream().map(LightResponse::from).toList();
-        }
+        double cellSize = cellSizeForBBox(minLng, maxLng);
         return mapClusterRows(passportRepository.findUserLightClusters(
                 targetUserId, minLat, maxLat, minLng, maxLng, toStringList(allowed), cellSize));
     }
 
-    // ========== 줌 레벨 → 셀 크기(degree) 매핑 ==========
-    // > zoom 16 이상이면 null 반환 — 클러스터링 안 함(기존 개별 응답 경로).
-    private static Double cellSizeForZoom(int zoom) {
-        if (zoom >= 16) return null;
-        if (zoom >= 13) return 0.001;
-        if (zoom >= 10) return 0.01;
-        if (zoom >= 6)  return 0.1;
-        return 1.0;
+    // ========== BBox 폭 → 셀 크기(degree) 자동 계산 ==========
+    // > 화면 폭의 1/50을 한 셀로 — 줌과 무관하게 항상 50칸 안팎의 격자로 클러스터링.
+    // > 셀 내 1건이면 mapClusterRows에서 자동으로 단일 응답으로 떨어지므로 임계값 분기 불필요.
+    private static double cellSizeForBBox(BigDecimal minLng, BigDecimal maxLng) {
+        return maxLng.subtract(minLng).doubleValue() / 50.0;
     }
 
     // ========== 클러스터링 쿼리 결과 → LightResponse 매핑 ==========
@@ -439,6 +422,40 @@ public class PassportService {
         if (o instanceof BigDecimal bd) return bd;
         if (o instanceof Number n) return BigDecimal.valueOf(n.doubleValue());
         return null;
+    }
+
+    // ========== 클러스터 셀 상세 리스트 ==========
+    public CursorResponse<PassportListResponse> getLightCluster(
+            Long userId, BigDecimal minLat, BigDecimal maxLat,
+            BigDecimal minLng, BigDecimal maxLng, Long teamId,
+            Long cursor, int size) {
+        validateBoundingBox(minLat, maxLat, minLng, maxLng);
+
+        List<Passport> passports;
+        if (teamId != null) {
+            if (!teamRepository.existsById(teamId)) {
+                throw new BusinessException(ErrorCode.TEAM_NOT_FOUND);
+            }
+            if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
+                throw new BusinessException(ErrorCode.TEAM_NOT_MEMBER);
+            }
+            passports = passportRepository.findTeamPassportsInBounds(
+                    teamId, minLat, maxLat, minLng, maxLng, cursor, PageRequest.of(0, size + 1));
+        } else {
+            List<Visibility> allowed = List.of(
+                    Visibility.PUBLIC, Visibility.PRIVATE, Visibility.FRIENDS_ONLY
+            );
+            passports = passportRepository.findUserPassportsInBounds(
+                    userId, allowed, minLat, maxLat, minLng, maxLng, cursor, PageRequest.of(0, size + 1));
+        }
+
+        boolean hasNext = passports.size() > size;
+        if (hasNext) passports = passports.subList(0, size);
+        Long nextCursor = hasNext ? passports.get(passports.size() - 1).getId() : null;
+        return CursorResponse.of(
+                passports.stream().map(PassportListResponse::from).toList(),
+                hasNext, nextCursor
+        );
     }
 
     private void validateBoundingBox(BigDecimal minLat, BigDecimal maxLat,

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -340,8 +340,9 @@ public class PassportService {
 
     // ========== 내 불빛 조회 ==========
     public List<LightResponse> getMyLights(Long userId, BigDecimal minLat, BigDecimal maxLat,
-                                           BigDecimal minLng, BigDecimal maxLng, Long teamId) {
+                                           BigDecimal minLng, BigDecimal maxLng, int zoom, Long teamId) {
         validateBoundingBox(minLat, maxLat, minLng, maxLng);
+        Double cellSize = cellSizeForZoom(zoom);
 
         // > teamId가 있으면 팀 모드: 팀 멤버십 검증 후 팀 여권만 BBox 조회. visibility 무시.
         if (teamId != null) {
@@ -351,33 +352,93 @@ public class PassportService {
             if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
                 throw new BusinessException(ErrorCode.TEAM_NOT_MEMBER);
             }
-            return passportRepository.findTeamLightsInBounds(teamId, minLat, maxLat, minLng, maxLng)
-                    .stream().map(LightResponse::from).toList();
+            if (cellSize == null) {
+                return passportRepository.findTeamLightsInBounds(teamId, minLat, maxLat, minLng, maxLng)
+                        .stream().map(LightResponse::from).toList();
+            }
+            return mapClusterRows(passportRepository.findTeamLightClusters(
+                    teamId, minLat, maxLat, minLng, maxLng, cellSize));
         }
 
         // > teamId 없으면 개인 모드: 본인 여권 전체 visibility 조회.
         List<Visibility> allowed = List.of(
                 Visibility.PUBLIC, Visibility.PRIVATE, Visibility.FRIENDS_ONLY
         );
-        return passportRepository.findLightsInBounds(userId, minLat, maxLat, minLng, maxLng,
-                        toStringList(allowed))
-                .stream().map(LightResponse::from).toList();
+        if (cellSize == null) {
+            return passportRepository.findLightsInBounds(userId, minLat, maxLat, minLng, maxLng,
+                            toStringList(allowed))
+                    .stream().map(LightResponse::from).toList();
+        }
+        return mapClusterRows(passportRepository.findUserLightClusters(
+                userId, minLat, maxLat, minLng, maxLng, toStringList(allowed), cellSize));
     }
 
     // ========== 특정 사용자 불빛 조회 ==========
     public List<LightResponse> getUserLights(Long viewerId, Long targetUserId,
                                              BigDecimal minLat, BigDecimal maxLat,
-                                             BigDecimal minLng, BigDecimal maxLng) {
+                                             BigDecimal minLng, BigDecimal maxLng, int zoom) {
         validateBoundingBox(minLat, maxLat, minLng, maxLng);
-        if (viewerId.equals(targetUserId)) return getMyLights(viewerId, minLat, maxLat, minLng, maxLng, null);
+        if (viewerId.equals(targetUserId)) {
+            return getMyLights(viewerId, minLat, maxLat, minLng, maxLng, zoom, null);
+        }
         if (!userRepository.existsById(targetUserId)) throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         boolean isFriend = friendRepository.isFriend(viewerId, targetUserId);
         List<Visibility> allowed = isFriend
                 ? List.of(Visibility.PUBLIC, Visibility.FRIENDS_ONLY)
                 : List.of(Visibility.PUBLIC);
-        return passportRepository.findLightsInBounds(targetUserId, minLat, maxLat, minLng, maxLng,
-                        toStringList(allowed))
-                .stream().map(LightResponse::from).toList();
+
+        Double cellSize = cellSizeForZoom(zoom);
+        if (cellSize == null) {
+            return passportRepository.findLightsInBounds(targetUserId, minLat, maxLat, minLng, maxLng,
+                            toStringList(allowed))
+                    .stream().map(LightResponse::from).toList();
+        }
+        return mapClusterRows(passportRepository.findUserLightClusters(
+                targetUserId, minLat, maxLat, minLng, maxLng, toStringList(allowed), cellSize));
+    }
+
+    // ========== 줌 레벨 → 셀 크기(degree) 매핑 ==========
+    // > zoom 16 이상이면 null 반환 — 클러스터링 안 함(기존 개별 응답 경로).
+    private static Double cellSizeForZoom(int zoom) {
+        if (zoom >= 16) return null;
+        if (zoom >= 13) return 0.001;
+        if (zoom >= 10) return 0.01;
+        if (zoom >= 6)  return 0.1;
+        return 1.0;
+    }
+
+    // ========== 클러스터링 쿼리 결과 → LightResponse 매핑 ==========
+    // > rows 각 행: [cnt(BIGINT), center_lat(numeric), center_lng(numeric), single_id(BIGINT or null)]
+    // > cnt=1인 셀은 single_id로 Passport 일괄 fetch 후 from(p)로 단일 응답.
+    // > cnt>=2인 셀은 cluster()로 묶음 응답 (단일 식별 필드 null).
+    private List<LightResponse> mapClusterRows(List<Object[]> rows) {
+        List<Long> singleIds = rows.stream()
+                .map(r -> r[3] == null ? null : ((Number) r[3]).longValue())
+                .filter(Objects::nonNull)
+                .toList();
+        Map<Long, Passport> singleMap = singleIds.isEmpty()
+                ? Map.of()
+                : passportRepository.findAllByIdsForFeed(singleIds).stream()
+                    .collect(Collectors.toMap(Passport::getId, p -> p));
+
+        return rows.stream().map(r -> {
+            long cnt = ((Number) r[0]).longValue();
+            Long singleId = r[3] == null ? null : ((Number) r[3]).longValue();
+            if (cnt == 1 && singleId != null) {
+                Passport p = singleMap.get(singleId);
+                if (p != null) return LightResponse.from(p);
+            }
+            BigDecimal centerLat = toBigDecimal(r[1]);
+            BigDecimal centerLng = toBigDecimal(r[2]);
+            return LightResponse.cluster(cnt, centerLat, centerLng);
+        }).toList();
+    }
+
+    private BigDecimal toBigDecimal(Object o) {
+        if (o == null) return null;
+        if (o instanceof BigDecimal bd) return bd;
+        if (o instanceof Number n) return BigDecimal.valueOf(n.doubleValue());
+        return null;
     }
 
     private void validateBoundingBox(BigDecimal minLat, BigDecimal maxLat,


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #82

## 📝 작업 내용

> 지도 위 불빛이 밀집될 때 백엔드에서 격자 단위로 묶어(클러스터링) 응답해 프론트 렌더링 비용을 줄임.
> 클러스터를 클릭했을 때 셀 내 여권 목록을 받는 상세 리스트 API와, 지도 관련 엔드포인트를 별도 `LightController`로 분리.

### 신규 생성
- `LightController.java` — 지도 불빛 API를 `@Tag(name = "Map")`으로 분리

### 기존 파일 수정
- `LightResponse.java` — `isCluster`, `count`, `centerLatitude`, `centerLongitude` 필드 추가. 클러스터 응답용 `cluster()` 정적 팩토리 추가
- `PassportRepository.java`
  - `findUserLightClusters` / `findTeamLightClusters` — **PostGIS `ST_SnapToGrid` + `GROUP BY`** 기반 클러스터링 쿼리. `AVG(lat/lng)`로 centroid, `CASE WHEN COUNT=1 THEN MIN(passport_id)`로 단일 셀의 ID 보존
  - `findUserPassportsInBounds` / `findTeamPassportsInBounds` — 셀 BBox 내 여권 커서 페이징 쿼리
  - 미사용된 `findLightsInBounds`, `findTeamLightsInBounds` 제거
- `PassportService.java`
- `PassportController.java` — `/lights/**` 엔드포인트 제거 (LightController로 이관)

### API 변경
| Method | Path | 설명 |
|---|---|---|
| GET | `/api/v1/lights/me` | 본인/팀 불빛 (클러스터링 자동 적용) |
| GET | `/api/v1/lights/{userId}` | 특정 사용자 불빛 (visibility 필터) |
| GET | `/api/v1/lights/cluster` | 클러스터 클릭 시 셀 내 여권 페이징 |

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.