### PR TITLE
FEAT: k6 부하 테스트용 dev 전용 토큰 발급 엔드포인트 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/auth/controller/DevAuthController.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/controller/DevAuthController.java
@@ -1,0 +1,53 @@
+package com.kauniv.lightrip.global.auth.controller;
+
+import com.kauniv.lightrip.global.auth.dto.TokenResponse;
+import com.kauniv.lightrip.global.jwt.JwtProvider;
+import com.kauniv.lightrip.global.redis.service.RedisService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// > dev 프로파일에서만 활성화되는 테스트용 토큰 발급 컨트롤러.
+// > @Profile("dev") 로 prod 배포 시 Bean 자체가 등록되지 않아 엔드포인트가 노출되지 않음.
+// > k6 부하 테스트 시 VU(가상 유저)별로 다른 userId 토큰을 setup()에서 발급받기 위해 사용.
+// > JwtProvider, RedisService를 그대로 재사용하므로 실제 로그인과 동일한 토큰 구조.
+@Profile("dev")
+@Tag(name = "Dev", description = "[DEV 전용] 테스트 토큰 발급 API")
+@RestController
+@RequestMapping("/dev")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+    // > JwtProvider: userId를 subject로 서명한 accessToken/refreshToken 생성
+    private final JwtProvider jwtProvider;
+
+    // > RedisService: 발급한 refreshToken을 Redis에 저장 (refresh:{userId} → hash(token))
+    // > 실제 로그인(OAuth2SuccessHandler)과 동일한 방식으로 저장해야 /auth/refresh 재사용 가능
+    private final RedisService redisService;
+
+    @Operation(
+            summary = "[DEV 전용] 테스트 토큰 발급",
+            description = "userId로 accessToken과 refreshToken을 즉시 발급합니다. dev 환경 전용이며 prod에서는 동작하지 않습니다."
+    )
+    @GetMapping("/token/{userId}")
+    public ResponseEntity<TokenResponse> getTestToken(@PathVariable Long userId) {
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String refreshToken = jwtProvider.generateRefreshToken(userId);
+
+        // > refreshToken을 Redis에 저장해야 /auth/refresh 호출 시 검증 통과
+        redisService.saveRefreshToken(userId, refreshToken, jwtProvider.getRefreshTokenExpiration());
+
+        return ResponseEntity.ok(
+                TokenResponse.builder()
+                        .accessToken(accessToken)
+                        .refreshToken(refreshToken)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/auth/dto/TokenResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/dto/TokenResponse.java
@@ -1,11 +1,16 @@
 package com.kauniv.lightrip.global.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
+// > accessToken은 항상 포함, refreshToken은 dev 토큰 발급 시에만 포함
+// > @JsonInclude(NON_NULL) 로 null 필드는 응답 JSON에서 제외
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TokenResponse {
 
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/", "/oauth2/**", "/login/**", "/auth/refresh",
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
-                                "/actuator/**", "/ws/**"
+                                "/actuator/**", "/ws/**",
+                                "/dev/**"   // dev 프로파일 전용 — @Profile("dev") 로 prod에서는 Bean 비활성화
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/{userId}").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #97

## 📝 작업 내용
k6 부하 테스트 시 VU(가상 유저)별로 독립적인 accessToken 발급을 위한 dev 전용 엔드포인트 추가.
카카오 OAuth2 딥링크 방식으로는 테스트 자동화가 불가능해 JwtProvider, RedisService를 직접 호출하는 방식으로 구현.

**변경 사항**

신규 생성
- `DevAuthController.java` — `@Profile("dev")` 적용, `GET /dev/token/{userId}`로 accessToken + refreshToken 즉시 발급

기존 파일 수정
- `TokenResponse.java` — `refreshToken` 필드 추가, `@JsonInclude(NON_NULL)` 적용 (기존 `/auth/refresh` 응답 영향 없음)
- `SecurityConfig.java` — `/dev/**` permitAll 추가

| 항목 | 내용 |
|------|------|
| prod 안전성 | `@Profile("dev")` 로 prod 배포 시 Bean 미등록 |
| EC2 적용 | `.env` → `SPRING_PROFILES_ACTIVE=prod`, `.env.dev` → `SPRING_PROFILES_ACTIVE=dev` 추가 완료 |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

