### PR TITLE
CHORE: 배포 서버 더미 데이터 제거 실행 기록 추가

### DIFF
--- a/src/main/resources/db/seed/dummy_seed_rollback.sql
+++ b/src/main/resources/db/seed/dummy_seed_rollback.sql
@@ -8,6 +8,13 @@
 --
 -- ⚠️ prod 환경에서 실행 시 사고 위험 — 반드시 RDS snapshot 후 실행
 -- =============================================================================
+-- [2026-05-27] 배포 서버 실제 실행 쿼리 (TRUNCATE 방식으로 전체 초기화)
+--   BEGIN;
+--   TRUNCATE TABLE passport_stamp, passport_image, likes, scrap,
+--                  district_cover, ranking, passport, team_member,
+--                  friend, auth, users, team CASCADE;
+--   COMMIT;
+-- =============================================================================
 
 BEGIN;
 


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #106 

## 📝 작업 내용

- 배포 서버 DB에 남아있던 더미 데이터를 `TRUNCATE ... CASCADE` 로 일괄 제거
- `dummy_seed_rollback.sql` 상단에 실제 실행한 쿼리를 주석으로 기록

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.