### PR TITLE
FEAT: AI 서버 호출에 JWT 인증 전달 및 text 파라미터 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -24,8 +25,9 @@ public class AiClient {
     private String aiServerUrl;
     // > application.properties의 ai.server.url 값 주입.
 
-    public AiResponse generate(String imageUrl) {
+    public AiResponse generate(String imageUrl, String text, String authorization) {
         // > CloudFront URL에서 이미지를 다운로드해서 FastAPI로 multipart 전송.
+        // > authorization: 사용자 요청의 Authorization 헤더("Bearer ...")를 AI 서버로 그대로 전달.
 
         // 1. 이미지 다운로드
         ResponseEntity<byte[]> imageResponse = restClient.get()
@@ -54,13 +56,20 @@ public class AiClient {
         });
         // > byte[]를 ByteArrayResource로 감싸야 multipart 전송 가능.
 
+        if (text != null) {
+            body.add("text", text);
+        }
+        // > 프론트가 전달한 설명 텍스트를 함께 전송. 없으면 image만 전송.
+
         // 4. FastAPI 호출
         return restClient.post()
                 .uri(aiServerUrl + "/pipeline/generate")
+                .header(HttpHeaders.AUTHORIZATION, authorization)
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(body)
                 .retrieve()
                 .body(AiResponse.class);
         // > POST /pipeline/generate 호출 후 AiResponse로 역직렬화.
+        // > AI 서버는 다른 API와 동일하게 Authorization 헤더의 JWT를 검증.
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/controller/AiController.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/controller/AiController.java
@@ -3,8 +3,10 @@ package com.kauniv.lightrip.global.ai.controller;
 import com.kauniv.lightrip.global.ai.service.AiService;
 import com.kauniv.lightrip.global.ai.dto.AiDraftResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,13 +19,18 @@ public class AiController {
     private final AiService aiService;
     // > AI 초안 생성 비즈니스 로직 담당.
 
-    @Operation(summary = "AI 초안 생성", description = "이미지 URL로 블로그 초안과 카테고리 초기값을 생성합니다.")
+    @Operation(summary = "AI 초안 생성", description = "이미지 URL과 설명 텍스트로 블로그 초안과 카테고리 초기값을 생성합니다.")
     @PostMapping("/draft")
-    public ResponseEntity<AiDraftResponse> generateDraft(@RequestParam String imageUrl) {
-        // > 프론트가 S3 업로드 후 받은 CloudFront URL을 전달.
+    public ResponseEntity<AiDraftResponse> generateDraft(
+            @RequestParam String imageUrl,
+            @RequestParam(required = false) String text,
+            @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
+    ) {
+        // > 프론트가 S3 업로드 후 받은 CloudFront URL과 설명 텍스트를 전달.
         // > 여권 등록 전에 호출해서 초안을 미리 보여주는 용도.
+        // > authorization: 사용자 JWT를 AI 서버로 그대로 전달.
 
-        AiDraftResponse response = aiService.generateDraft(imageUrl);
+        AiDraftResponse response = aiService.generateDraft(imageUrl, text, authorization);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
@@ -16,10 +16,11 @@ public class AiService {
     private final AiClient aiClient;
     // > FastAPI 호출 담당 클라이언트.
 
-    public AiDraftResponse generateDraft(String imageUrl) {
-        // > 이미지 URL로 AI 초안과 카테고리 초기값을 생성해서 반환.
+    public AiDraftResponse generateDraft(String imageUrl, String text, String authorization) {
+        // > 이미지 URL과 설명 텍스트로 AI 초안과 카테고리 초기값을 생성해서 반환.
+        // > authorization: 사용자 JWT를 AI 서버로 전달하기 위한 Authorization 헤더값.
 
-        AiResponse aiResponse = aiClient.generate(imageUrl);
+        AiResponse aiResponse = aiClient.generate(imageUrl, text, authorization);
         // > FastAPI /pipeline/generate 호출.
 
         if (aiResponse == null) {

--- a/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
@@ -36,12 +36,20 @@ public class AiService {
 
     private Category parseCategory(String categoryStr) {
         // > AI 반환값을 Category enum으로 안전하게 변환.
-        // > 매핑 실패 시 ETC로 폴백.
-        try {
-            return Category.valueOf(categoryStr);
-        } catch (IllegalArgumentException e) {
-            log.warn("AI 카테고리 매핑 실패: {} → ETC로 폴백", categoryStr);
+        // > AI 서버는 한글 라벨(displayName, 예: "카페")을 반환하므로 displayName으로 매칭.
+        // > 영문 enum 이름(예: "CAFE")도 허용. 매핑 실패 시 ETC로 폴백.
+        if (categoryStr == null) {
             return Category.ETC;
         }
+
+        String value = categoryStr.trim();
+        for (Category category : Category.values()) {
+            if (category.getDisplayName().equals(value) || category.name().equalsIgnoreCase(value)) {
+                return category;
+            }
+        }
+
+        log.warn("AI 카테고리 매핑 실패: {} → ETC로 폴백", categoryStr);
+        return Category.ETC;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
> Closes #119

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

별도 배포된 **AI 서버(`https://ai.lightrip.cloud`)** 호출에 **JWT 인증**을 적용하고, 요청에 **설명 텍스트(`text`)**를 함께 전송하도록 변경

- AI 서버 `POST /pipeline/generate` 호출 시 사용자 요청의 `Authorization` 헤더(JWT)를 그대로 forward → AI 서버가 백엔드와 동일한 `JWT_SECRET`으로 검증
- multipart 요청에 `image` + `text`(설명) 함께 전송 (기존엔 `image`만 전송)
- `AiController`: `text`(optional), `Authorization` 헤더 파라미터 추가
  - `Authorization`은 Swagger 전역 `BearerAuth` 스킴으로 자동 전송되므로 `@Parameter(hidden = true)`로 입력 필드 노출 제외
- `AiService` / `AiClient`: `generate` 시그니처에 `text`, `authorization` 전달

**변경 파일**
- `global/ai/controller/AiController.java`
- `global/ai/service/AiService.java`
- `global/ai/AiClient.java`


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.