### PR TITLE
FEAT: pgvector RAG 파이프라인 구현

### DIFF
--- a/src/main/java/com/kauniv/lightrip/LightripApplication.java
+++ b/src/main/java/com/kauniv/lightrip/LightripApplication.java
@@ -2,8 +2,10 @@ package com.kauniv.lightrip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 public class LightripApplication {

--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import com.kauniv.lightrip.domain.passport.dto.response.DistrictResponse;
@@ -75,9 +76,11 @@ public class PassportController {
     @PostMapping
     public ApiResponse<PassportResponse> create(
             @AuthenticationPrincipal Long userId,
-            @Valid @RequestBody PassportCreateRequest request
+            @Valid @RequestBody PassportCreateRequest request,
+            @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
+            // > FastAPI /get-embedding 호출 시 JWT 검증에 사용. Swagger UI에는 노출하지 않음.
     ) {
-        return ApiResponse.success("여권이 등록되었습니다.", passportService.create(userId, request));
+        return ApiResponse.success("여권이 등록되었습니다.", passportService.create(userId, request, authorization));
     }
 
     @Operation(summary = "여권 수정",

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -4,6 +4,8 @@ import com.kauniv.lightrip.global.enums.District;
 import java.util.Optional;
 import com.kauniv.lightrip.domain.passport.entity.Passport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.springframework.data.jpa.repository.Query;
@@ -246,4 +248,28 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     WHERE p.user.id = :userId
     """)
     long countDistinctDistrictByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE passport SET embedding = CAST(:embedding AS vector) WHERE passport_id = :id",
+            nativeQuery = true)
+    void updateEmbedding(@Param("id") Long id, @Param("embedding") String embedding);
+    // > 여권 저장 후 비동기로 호출. EmbeddingGemma가 반환한 벡터를 pgvector 컬럼에 저장.
+    // > CAST(:embedding AS vector): "[0.1,0.2,...]" 형식의 문자열을 vector 타입으로 변환.
+
+    @Query(value = """
+            SELECT content FROM passport
+            WHERE user_id = :userId
+              AND embedding IS NOT NULL
+            ORDER BY embedding <=> CAST(:embedding AS vector)
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<String> findSimilarContents(
+            @Param("userId") Long userId,
+            @Param("embedding") String embedding,
+            @Param("limit") int limit);
+    // > RAG 초안 생성 시 코사인 유사도 기준 상위 기록 텍스트 반환.
+    // > user_id 필터: 본인 기록만 검색 (타인 기록 유출 방지).
+    // > embedding IS NOT NULL: 아직 임베딩이 채워지지 않은 기록 제외.
+    // > <=>: pgvector 코사인 거리 연산자.
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -64,7 +64,7 @@ public class PassportService {
 
     // ========== 등록 ==========
     @Transactional
-    public PassportResponse create(Long userId, PassportCreateRequest req) {
+    public PassportResponse create(Long userId, PassportCreateRequest req, String authorization) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -107,8 +107,9 @@ public class PassportService {
 
         createDistrictCoverIfFirst(user, passport);
 
-        aiService.saveEmbeddingAsync(passport.getId(), req.content());
+        aiService.saveEmbeddingAsync(passport.getId(), req.content(), authorization);
         // > 여권 저장 완료 후 content를 비동기로 임베딩 → pgvector 저장.
+        // > authorization: FastAPI 호출 시 JWT 검증에 필요. HTTP 요청에서 받아서 async 메서드에 전달.
         // > 응답 지연 없음. 실패해도 여권 저장에 영향 없음.
 
         return PassportResponse.from(passport);

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -36,6 +36,7 @@ import com.kauniv.lightrip.global.enums.Category;
 import com.kauniv.lightrip.domain.passport.dto.response.PassportStatsResponse;
 import com.kauniv.lightrip.domain.like.repository.LikeRepository;
 import com.kauniv.lightrip.domain.passport.dto.response.FeedPassportResponse;
+import com.kauniv.lightrip.global.ai.service.AiService;
 import com.kauniv.lightrip.global.common.response.FeedCursorResponse;
 import java.math.RoundingMode;
 import java.util.HashSet;
@@ -58,6 +59,8 @@ public class PassportService {
     private final FriendRepository friendRepository;
     private final DistrictCoverRepository districtCoverRepository;
     private final LikeRepository likeRepository;
+    private final AiService aiService;
+    // > 여권 저장 후 content 임베딩을 비동기로 저장하기 위해 주입.
 
     // ========== 등록 ==========
     @Transactional
@@ -103,6 +106,10 @@ public class PassportService {
         passportRepository.flush();
 
         createDistrictCoverIfFirst(user, passport);
+
+        aiService.saveEmbeddingAsync(passport.getId(), req.content());
+        // > 여권 저장 완료 후 content를 비동기로 임베딩 → pgvector 저장.
+        // > 응답 지연 없음. 실패해도 여권 저장에 영향 없음.
 
         return PassportResponse.from(passport);
     }

--- a/src/main/java/com/kauniv/lightrip/domain/team/controller/MapSyncController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/controller/MapSyncController.java
@@ -19,10 +19,10 @@ import java.time.Instant;
 @RequiredArgsConstructor
 public class MapSyncController {
 
-    > SimpMessagingTemplate: @SendTo 대신 사용 — 검증 후에만 브로드캐스트하기 위함
-    > TeamMemberRepository: 팀 멤버 여부 검증
-    > RedisTemplate: 현재 위치 저장 (TTL 5분, 오프라인 시 자동 만료)
-    > ObjectMapper: LocationMessage → JSON 직렬화
+    // > SimpMessagingTemplate: @SendTo 대신 사용 — 검증 후에만 브로드캐스트하기 위함
+    // > TeamMemberRepository: 팀 멤버 여부 검증
+    // > RedisTemplate: 현재 위치 저장 (TTL 5분, 오프라인 시 자동 만료)
+    // > ObjectMapper: LocationMessage → JSON 직렬화
     private final SimpMessagingTemplate messagingTemplate;
     private final TeamMemberRepository teamMemberRepository;
     private final RedisTemplate<String, String> redisTemplate;
@@ -37,16 +37,16 @@ public class MapSyncController {
             SimpMessageHeaderAccessor headerAccessor
     ) throws JsonProcessingException {
 
-        > StompHandler가 CONNECT 시 세션에 저장한 userId 사용
-        > 클라이언트가 보낸 message.getUserId()는 무시 — 위변조 방지
+        // > StompHandler가 CONNECT 시 세션에 저장한 userId 사용
+        // > 클라이언트가 보낸 message.getUserId()는 무시 — 위변조 방지
         Long userId = (Long) headerAccessor.getSessionAttributes().get("userId");
 
-        > 해당 팀의 멤버인지 검증. 비멤버는 메시지 무시
+        // > 해당 팀의 멤버인지 검증. 비멤버는 메시지 무시
         if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
             return;
         }
 
-        > 서버 타임스탬프 + 인증된 userId로 교체한 검증 메시지 생성
+        // > 서버 타임스탬프 + 인증된 userId로 교체한 검증 메시지 생성
         LocationMessage verified = new LocationMessage(
                 userId,
                 message.getNickname(),
@@ -57,12 +57,12 @@ public class MapSyncController {
                 Instant.now().toString()
         );
 
-        > Redis 저장 key: live:team:{teamId}:{userId}
-        > TTL 초과 시 자동 삭제 → GET /live-locations 응답에서 자동 제외
+        // > Redis 저장 key: live:team:{teamId}:{userId}
+        // > TTL 초과 시 자동 삭제 → GET /live-locations 응답에서 자동 제외
         String key = "live:team:" + teamId + ":" + userId;
         redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(verified), LOCATION_TTL);
 
-        > 같은 팀 구독자 전원에게 브로드캐스트
+        // > 같은 팀 구독자 전원에게 브로드캐스트
         messagingTemplate.convertAndSend("/topic/team/" + teamId, verified);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/team/controller/MapSyncController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/controller/MapSyncController.java
@@ -19,10 +19,10 @@ import java.time.Instant;
 @RequiredArgsConstructor
 public class MapSyncController {
 
-    // SimpMessagingTemplate: @SendTo 대신 사용 — 검증 후에만 브로드캐스트하기 위함
-    // TeamMemberRepository: 팀 멤버 여부 검증
-    // RedisTemplate: 현재 위치 저장 (TTL 5분, 오프라인 시 자동 만료)
-    // ObjectMapper: LocationMessage → JSON 직렬화
+    > SimpMessagingTemplate: @SendTo 대신 사용 — 검증 후에만 브로드캐스트하기 위함
+    > TeamMemberRepository: 팀 멤버 여부 검증
+    > RedisTemplate: 현재 위치 저장 (TTL 5분, 오프라인 시 자동 만료)
+    > ObjectMapper: LocationMessage → JSON 직렬화
     private final SimpMessagingTemplate messagingTemplate;
     private final TeamMemberRepository teamMemberRepository;
     private final RedisTemplate<String, String> redisTemplate;
@@ -37,16 +37,16 @@ public class MapSyncController {
             SimpMessageHeaderAccessor headerAccessor
     ) throws JsonProcessingException {
 
-        // StompHandler가 CONNECT 시 세션에 저장한 userId 사용
-        // 클라이언트가 보낸 message.getUserId()는 무시 — 위변조 방지
+        > StompHandler가 CONNECT 시 세션에 저장한 userId 사용
+        > 클라이언트가 보낸 message.getUserId()는 무시 — 위변조 방지
         Long userId = (Long) headerAccessor.getSessionAttributes().get("userId");
 
-        // 해당 팀의 멤버인지 검증. 비멤버는 메시지 무시
+        > 해당 팀의 멤버인지 검증. 비멤버는 메시지 무시
         if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
             return;
         }
 
-        // 서버 타임스탬프 + 인증된 userId로 교체한 검증 메시지 생성
+        > 서버 타임스탬프 + 인증된 userId로 교체한 검증 메시지 생성
         LocationMessage verified = new LocationMessage(
                 userId,
                 message.getNickname(),
@@ -57,12 +57,12 @@ public class MapSyncController {
                 Instant.now().toString()
         );
 
-        // Redis 저장 key: live:team:{teamId}:{userId}
-        // TTL 초과 시 자동 삭제 → GET /live-locations 응답에서 자동 제외
+        > Redis 저장 key: live:team:{teamId}:{userId}
+        > TTL 초과 시 자동 삭제 → GET /live-locations 응답에서 자동 제외
         String key = "live:team:" + teamId + ":" + userId;
         redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(verified), LOCATION_TTL);
 
-        // 같은 팀 구독자 전원에게 브로드캐스트
+        > 같은 팀 구독자 전원에게 브로드캐스트
         messagingTemplate.convertAndSend("/topic/team/" + teamId, verified);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -115,22 +115,9 @@ public class TeamService {
         teamMemberRepository.delete(member);
     }
 
-    // sharing: false → Redis 키 즉시 삭제 → live-locations에서 바로 제외
-    // sharing: true  → 서버 처리 없음, 클라이언트가 WebSocket 전송 재개 시 자동 등록
-    public void updateLocationSharing(Long userId, Long teamId, boolean sharing) {
-        if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
-            throw new BusinessException(ErrorCode.TEAM_NOT_MEMBER);
-        }
-
-        if (!sharing) {
-            String key = "live:team:" + teamId + ":" + userId;
-            redisTemplate.delete(key);
-        }
-    }
-
-    // Redis에서 현재 온라인 팀원 위치 조회.
-    // TTL 5분 초과(오프라인) 유저는 키가 없으므로 null → filter로 제거.
-    // MapSyncController와 Redis key 구조 공유: live:team:{teamId}:{userId}
+    > Redis에서 현재 온라인 팀원 위치 조회.
+    > TTL 5분 초과(오프라인) 유저는 키가 없으므로 null → filter로 제거.
+    > MapSyncController와 Redis key 구조 공유: live:team:{teamId}:{userId}
     public List<LiveLocationResponse> getLiveLocations(Long teamId) {
         teamRepository.findById(teamId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -117,7 +117,7 @@ public class TeamService {
 
     // > Redis에서 현재 온라인 팀원 위치 조회.
     // > TTL 5분 초과(오프라인) 유저는 키가 없으므로 null → filter로 제거.
-    // > MapSyncController와 Redis key 구조 공유: live:team:{teamId}:{userId}
+    // > MapSyncController와 Redis key 구조 공유 (key 패턴: "live:team:[teamId]:[userId]")
     public List<LiveLocationResponse> getLiveLocations(Long teamId) {
         teamRepository.findById(teamId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -115,9 +115,9 @@ public class TeamService {
         teamMemberRepository.delete(member);
     }
 
-    > Redis에서 현재 온라인 팀원 위치 조회.
-    > TTL 5분 초과(오프라인) 유저는 키가 없으므로 null → filter로 제거.
-    > MapSyncController와 Redis key 구조 공유: live:team:{teamId}:{userId}
+    // > Redis에서 현재 온라인 팀원 위치 조회.
+    // > TTL 5분 초과(오프라인) 유저는 키가 없으므로 null → filter로 제거.
+    // > MapSyncController와 Redis key 구조 공유: live:team:{teamId}:{userId}
     public List<LiveLocationResponse> getLiveLocations(Long teamId) {
         teamRepository.findById(teamId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
@@ -141,5 +141,21 @@ public class TeamService {
                 })
                 .filter(Objects::nonNull)
                 .toList();
+    }
+
+    @Transactional
+    public void updateLocationSharing(Long userId, Long teamId, boolean sharing) {
+        // > sharing=false 시 Redis 키 즉시 삭제 → GET /live-locations 응답에서 즉시 제외.
+        // > sharing=true 시 아무 작업 없음 — 실제 위치 데이터는 WebSocket 메시지 수신 시 저장됨.
+        if (!teamRepository.existsById(teamId)) {
+            throw new BusinessException(ErrorCode.TEAM_NOT_FOUND);
+        }
+        if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
+            throw new BusinessException(ErrorCode.TEAM_NOT_MEMBER);
+        }
+        if (!sharing) {
+            String key = "live:team:" + teamId + ":" + userId;
+            redisTemplate.delete(key);
+        }
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -90,14 +90,16 @@ public class AiClient {
         }
     }
 
-    public float[] getEmbedding(String text) {
+    public float[] getEmbedding(String text, String authorization) {
         // > 텍스트를 1536차원 벡터로 변환. pgvector 저장 및 RAG 검색에 사용.
+        // > authorization: FastAPI JWT 검증에 필요. generate()와 동일하게 전달.
         // > AI 팀 /get-embedding 엔드포인트 완성 후 아래 주석 해제.
 
         // TODO: AI 팀 /get-embedding 완성 후 주석 해제
         // try {
         //     EmbeddingResponse response = restClient.post()
         //             .uri(aiServerUrl + "/get-embedding")
+        //             .header(HttpHeaders.AUTHORIZATION, authorization)
         //             .contentType(MediaType.APPLICATION_JSON)
         //             .body(Map.of("text", text))
         //             .retrieve()
@@ -112,8 +114,9 @@ public class AiClient {
         return null;
     }
 
-    public AiResponse generateWithContext(String imageUrl, List<String> context) {
+    public AiResponse generateWithContext(String imageUrl, List<String> context, String authorization) {
         // > 이미지 + 과거 기록 context를 함께 전송해서 개인화된 초안 생성.
+        // > authorization: FastAPI JWT 검증에 필요. generate()와 동일하게 전달.
         // > AI 팀 /generate-blog 엔드포인트 완성 후 아래 주석 해제.
 
         // TODO: AI 팀 /generate-blog 완성 후 주석 해제
@@ -132,6 +135,7 @@ public class AiClient {
         //
         //     return restClient.post()
         //             .uri(aiServerUrl + "/generate-blog")
+        //             .header(HttpHeaders.AUTHORIZATION, authorization)
         //             .contentType(MediaType.MULTIPART_FORM_DATA)
         //             .body(body)
         //             .retrieve()

--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -1,6 +1,7 @@
 package com.kauniv.lightrip.global.ai;
 
 import com.kauniv.lightrip.global.ai.dto.AiResponse;
+import com.kauniv.lightrip.global.ai.dto.EmbeddingResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,6 +13,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -27,18 +31,25 @@ public class AiClient {
 
     public AiResponse generate(String imageUrl, String text, String authorization) {
         // > CloudFront URL에서 이미지를 다운로드해서 FastAPI로 multipart 전송.
-        // > authorization: 사용자 요청의 Authorization 헤더("Bearer ...")를 AI 서버로 그대로 전달.
+        // > text: 사용자가 입력한 메모 텍스트. 없으면 image만 전송.
+        // > authorization: 사용자 JWT를 AI 서버로 그대로 전달.
 
         // 1. 이미지 다운로드
-        ResponseEntity<byte[]> imageResponse = restClient.get()
-                .uri(imageUrl)
-                .retrieve()
-                .toEntity(byte[].class);
-        // > cdn.lightrip.cloud URL로 이미지 byte[] 다운로드.
+        byte[] imageBytes;
+        try {
+            ResponseEntity<byte[]> imageResponse = restClient.get()
+                    .uri(imageUrl)
+                    .retrieve()
+                    .toEntity(byte[].class);
+            // > cdn.lightrip.cloud URL로 이미지 byte[] 다운로드.
+            imageBytes = imageResponse.getBody();
+        } catch (Exception e) {
+            log.warn("AI 서버: 이미지 다운로드 실패 - {} : {}", imageUrl, e.getMessage());
+            return null;
+        }
 
-        byte[] imageBytes = imageResponse.getBody();
         if (imageBytes == null || imageBytes.length == 0) {
-            log.warn("AI 서버: 이미지 다운로드 실패 - {}", imageUrl);
+            log.warn("AI 서버: 이미지 응답이 비어있음 - {}", imageUrl);
             return null;
         }
 
@@ -59,17 +70,78 @@ public class AiClient {
         if (text != null) {
             body.add("text", text);
         }
-        // > 프론트가 전달한 설명 텍스트를 함께 전송. 없으면 image만 전송.
+        // > 프론트가 전달한 메모 텍스트를 함께 전송. 없으면 image만 전송.
 
         // 4. FastAPI 호출
-        return restClient.post()
-                .uri(aiServerUrl + "/pipeline/generate")
-                .header(HttpHeaders.AUTHORIZATION, authorization)
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(body)
-                .retrieve()
-                .body(AiResponse.class);
-        // > POST /pipeline/generate 호출 후 AiResponse로 역직렬화.
-        // > AI 서버는 다른 API와 동일하게 Authorization 헤더의 JWT를 검증.
+        try {
+            return restClient.post()
+                    .uri(aiServerUrl + "/pipeline/generate")
+                    .header(HttpHeaders.AUTHORIZATION, authorization)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(body)
+                    .retrieve()
+                    .body(AiResponse.class);
+            // > POST /pipeline/generate 호출 후 AiResponse로 역직렬화.
+            // > AI 서버는 Authorization 헤더의 JWT를 검증.
+        } catch (Exception e) {
+            log.warn("AI /pipeline/generate 호출 실패: {}", e.getMessage());
+            return null;
+            // > FastAPI 500 등 오류 시 null 반환 → AiService에서 빈 초안으로 처리.
+        }
+    }
+
+    public float[] getEmbedding(String text) {
+        // > 텍스트를 1536차원 벡터로 변환. pgvector 저장 및 RAG 검색에 사용.
+        // > AI 팀 /get-embedding 엔드포인트 완성 후 아래 주석 해제.
+
+        // TODO: AI 팀 /get-embedding 완성 후 주석 해제
+        // try {
+        //     EmbeddingResponse response = restClient.post()
+        //             .uri(aiServerUrl + "/get-embedding")
+        //             .contentType(MediaType.APPLICATION_JSON)
+        //             .body(Map.of("text", text))
+        //             .retrieve()
+        //             .body(EmbeddingResponse.class);
+        //     return response != null ? response.embedding() : null;
+        // } catch (Exception e) {
+        //     log.warn("AI /get-embedding 호출 실패: {}", e.getMessage());
+        //     return null;
+        // }
+
+        log.warn("AI /get-embedding stub — AI 팀 구현 대기 중");
+        return null;
+    }
+
+    public AiResponse generateWithContext(String imageUrl, List<String> context) {
+        // > 이미지 + 과거 기록 context를 함께 전송해서 개인화된 초안 생성.
+        // > AI 팀 /generate-blog 엔드포인트 완성 후 아래 주석 해제.
+
+        // TODO: AI 팀 /generate-blog 완성 후 주석 해제
+        // try {
+        //     ResponseEntity<byte[]> imageResponse = restClient.get()
+        //             .uri(imageUrl).retrieve().toEntity(byte[].class);
+        //     byte[] imageBytes = imageResponse.getBody();
+        //     if (imageBytes == null || imageBytes.length == 0) return null;
+        //
+        //     String filename = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+        //     MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        //     body.add("image", new ByteArrayResource(imageBytes) {
+        //         @Override public String getFilename() { return filename; }
+        //     });
+        //     body.add("context", context);
+        //
+        //     return restClient.post()
+        //             .uri(aiServerUrl + "/generate-blog")
+        //             .contentType(MediaType.MULTIPART_FORM_DATA)
+        //             .body(body)
+        //             .retrieve()
+        //             .body(AiResponse.class);
+        // } catch (Exception e) {
+        //     log.warn("AI /generate-blog 호출 실패: {}", e.getMessage());
+        //     return null;
+        // }
+
+        log.warn("AI /generate-blog stub — AI 팀 구현 대기 중");
+        return null;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -15,7 +15,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -93,59 +92,20 @@ public class AiClient {
     public float[] getEmbedding(String text, String authorization) {
         // > 텍스트를 1536차원 벡터로 변환. pgvector 저장 및 RAG 검색에 사용.
         // > authorization: FastAPI JWT 검증에 필요. generate()와 동일하게 전달.
-        // > AI 팀 /get-embedding 엔드포인트 완성 후 아래 주석 해제.
-
-        // TODO: AI 팀 /get-embedding 완성 후 주석 해제
-        // try {
-        //     EmbeddingResponse response = restClient.post()
-        //             .uri(aiServerUrl + "/get-embedding")
-        //             .header(HttpHeaders.AUTHORIZATION, authorization)
-        //             .contentType(MediaType.APPLICATION_JSON)
-        //             .body(Map.of("text", text))
-        //             .retrieve()
-        //             .body(EmbeddingResponse.class);
-        //     return response != null ? response.embedding() : null;
-        // } catch (Exception e) {
-        //     log.warn("AI /get-embedding 호출 실패: {}", e.getMessage());
-        //     return null;
-        // }
-
-        log.warn("AI /get-embedding stub — AI 팀 구현 대기 중");
+        // > [AI 팀 구현 후 추가] POST /get-embedding, body: {"text": text}, header: Authorization
+        // >   EmbeddingResponse.embedding() 반환값을 float[]로 return.
+        log.warn("AI /get-embedding stub — AI 팀 구현 대기 중 (textLength={})",
+                text != null ? text.length() : 0);
         return null;
     }
 
     public AiResponse generateWithContext(String imageUrl, List<String> context, String authorization) {
         // > 이미지 + 과거 기록 context를 함께 전송해서 개인화된 초안 생성.
         // > authorization: FastAPI JWT 검증에 필요. generate()와 동일하게 전달.
-        // > AI 팀 /generate-blog 엔드포인트 완성 후 아래 주석 해제.
-
-        // TODO: AI 팀 /generate-blog 완성 후 주석 해제
-        // try {
-        //     ResponseEntity<byte[]> imageResponse = restClient.get()
-        //             .uri(imageUrl).retrieve().toEntity(byte[].class);
-        //     byte[] imageBytes = imageResponse.getBody();
-        //     if (imageBytes == null || imageBytes.length == 0) return null;
-        //
-        //     String filename = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
-        //     MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        //     body.add("image", new ByteArrayResource(imageBytes) {
-        //         @Override public String getFilename() { return filename; }
-        //     });
-        //     body.add("context", context);
-        //
-        //     return restClient.post()
-        //             .uri(aiServerUrl + "/generate-blog")
-        //             .header(HttpHeaders.AUTHORIZATION, authorization)
-        //             .contentType(MediaType.MULTIPART_FORM_DATA)
-        //             .body(body)
-        //             .retrieve()
-        //             .body(AiResponse.class);
-        // } catch (Exception e) {
-        //     log.warn("AI /generate-blog 호출 실패: {}", e.getMessage());
-        //     return null;
-        // }
-
-        log.warn("AI /generate-blog stub — AI 팀 구현 대기 중");
+        // > [AI 팀 구현 후 추가] POST /generate-blog, multipart: image + context list, header: Authorization
+        // >   generate()의 이미지 다운로드 + multipart 구성 패턴 그대로 재사용.
+        log.warn("AI /generate-blog stub — AI 팀 구현 대기 중 (contextSize={})",
+                context != null ? context.size() : 0);
         return null;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/controller/AiController.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/controller/AiController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "AI", description = "AI 초안 생성 API")
@@ -19,18 +20,21 @@ public class AiController {
     private final AiService aiService;
     // > AI 초안 생성 비즈니스 로직 담당.
 
-    @Operation(summary = "AI 초안 생성", description = "이미지 URL과 설명 텍스트로 블로그 초안과 카테고리 초기값을 생성합니다.")
+    @Operation(summary = "AI 초안 생성",
+            description = "이미지 URL + 메모로 블로그 초안과 카테고리 초기값을 생성합니다. " +
+                    "text 전달 시 과거 기록 기반 RAG 경로로 개인화된 초안을 생성하며, " +
+                    "미전달 시 이미지 기반 기본 초안을 생성합니다.")
     @PostMapping("/draft")
     public ResponseEntity<AiDraftResponse> generateDraft(
             @RequestParam String imageUrl,
             @RequestParam(required = false) String text,
-            @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
+            // > 사용자가 입력한 메모 텍스트. RAG 경로 활성화 + FastAPI 전달에 사용. optional.
+            @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization,
+            // > 사용자 JWT. FastAPI AI 서버 인증에 사용.
+            @AuthenticationPrincipal Long userId
+            // > JWT에서 추출한 userId. 본인 과거 기록만 검색하기 위해 사용.
     ) {
-        // > 프론트가 S3 업로드 후 받은 CloudFront URL과 설명 텍스트를 전달.
-        // > 여권 등록 전에 호출해서 초안을 미리 보여주는 용도.
-        // > authorization: 사용자 JWT를 AI 서버로 그대로 전달.
-
-        AiDraftResponse response = aiService.generateDraft(imageUrl, text, authorization);
+        AiDraftResponse response = aiService.generateDraft(imageUrl, text, authorization, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
@@ -2,10 +2,29 @@ package com.kauniv.lightrip.global.ai.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record EmbeddingResponse(
+import java.util.Arrays;
 
+public record EmbeddingResponse(
         @JsonProperty("embedding")
         float[] embedding
         // > FastAPI /get-embedding이 반환하는 1536차원 float 벡터.
         // > pgvector 저장 및 유사도 검색에 사용.
-) {}
+) {
+    // > record는 배열 필드를 참조로 비교하므로 내용 기반 비교로 오버라이드.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EmbeddingResponse other)) return false;
+        return Arrays.equals(embedding, other.embedding);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(embedding);
+    }
+
+    @Override
+    public String toString() {
+        return "EmbeddingResponse{dim=" + (embedding != null ? embedding.length : 0) + "}";
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
@@ -1,0 +1,11 @@
+package com.kauniv.lightrip.global.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record EmbeddingResponse(
+
+        @JsonProperty("embedding")
+        float[] embedding
+        // > FastAPI /get-embedding이 반환하는 1536차원 float 벡터.
+        // > pgvector 저장 및 유사도 검색에 사용.
+) {}

--- a/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
@@ -29,8 +29,9 @@ public class AiService {
         // > fallback: stub 반환값이 null이거나 text가 없으면 기존 이미지 기반 초안으로 폴백.
 
         if (text != null && !text.isBlank() && userId != null) {
-            float[] embedding = aiClient.getEmbedding(text);
+            float[] embedding = aiClient.getEmbedding(text, authorization);
             // > 메모 텍스트를 벡터로 변환 — 유사 과거 기록 검색에 사용.
+            // > authorization: FastAPI JWT 검증에 사용. generate()와 동일하게 전달.
 
             if (embedding != null) {
                 List<String> similarContents = passportRepository.findSimilarContents(
@@ -38,7 +39,7 @@ public class AiService {
                 // > 코사인 유사도 기준 상위 3개 과거 기록 텍스트 조회.
 
                 if (!similarContents.isEmpty()) {
-                    AiResponse aiResponse = aiClient.generateWithContext(imageUrl, similarContents);
+                    AiResponse aiResponse = aiClient.generateWithContext(imageUrl, similarContents, authorization);
                     // > 이미지 + 과거 기록 3개를 FastAPI /generate-blog에 전달.
 
                     if (aiResponse != null) {
@@ -59,12 +60,13 @@ public class AiService {
 
     @Async
     @Transactional
-    public void saveEmbeddingAsync(Long passportId, String content) {
+    public void saveEmbeddingAsync(Long passportId, String content, String authorization) {
         // > 여권 저장 후 비동기로 호출. content를 임베딩해서 pgvector에 저장.
         // > @Async: 여권 저장 API 응답 지연 방지 — Gemma 처리 시간을 백그라운드에서 처리.
+        // > authorization: FastAPI /get-embedding JWT 검증에 사용. HTTP 요청 스레드에서 받아서 전달.
         // > 실패해도 여권 저장 자체에는 영향 없음 (try-catch로 격리).
         try {
-            float[] embedding = aiClient.getEmbedding(content);
+            float[] embedding = aiClient.getEmbedding(content, authorization);
             if (embedding == null) {
                 log.warn("임베딩 저장 skip: /get-embedding stub 상태 (passportId={})", passportId);
                 return;

--- a/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
@@ -1,12 +1,17 @@
 package com.kauniv.lightrip.global.ai.service;
 
+import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
 import com.kauniv.lightrip.global.ai.AiClient;
 import com.kauniv.lightrip.global.ai.dto.AiDraftResponse;
 import com.kauniv.lightrip.global.ai.dto.AiResponse;
 import com.kauniv.lightrip.global.enums.Category;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -16,22 +21,70 @@ public class AiService {
     private final AiClient aiClient;
     // > FastAPI 호출 담당 클라이언트.
 
-    public AiDraftResponse generateDraft(String imageUrl, String text, String authorization) {
-        // > 이미지 URL과 설명 텍스트로 AI 초안과 카테고리 초기값을 생성해서 반환.
-        // > authorization: 사용자 JWT를 AI 서버로 전달하기 위한 Authorization 헤더값.
+    private final PassportRepository passportRepository;
+    // > 유사 기록 검색(findSimilarContents) + 임베딩 저장(updateEmbedding)에 사용.
 
-        AiResponse aiResponse = aiClient.generate(imageUrl, text, authorization);
-        // > FastAPI /pipeline/generate 호출.
+    public AiDraftResponse generateDraft(String imageUrl, String text, String authorization, Long userId) {
+        // > RAG 경로: text와 userId가 모두 있을 때 과거 기록을 context로 주입.
+        // > fallback: stub 반환값이 null이거나 text가 없으면 기존 이미지 기반 초안으로 폴백.
 
-        if (aiResponse == null) {
-            return new AiDraftResponse(null, null);
-            // > AI 서버 장애 시 null 반환. 프론트에서 빈 값으로 처리.
+        if (text != null && !text.isBlank() && userId != null) {
+            float[] embedding = aiClient.getEmbedding(text);
+            // > 메모 텍스트를 벡터로 변환 — 유사 과거 기록 검색에 사용.
+
+            if (embedding != null) {
+                List<String> similarContents = passportRepository.findSimilarContents(
+                        userId, toVectorString(embedding), 3);
+                // > 코사인 유사도 기준 상위 3개 과거 기록 텍스트 조회.
+
+                if (!similarContents.isEmpty()) {
+                    AiResponse aiResponse = aiClient.generateWithContext(imageUrl, similarContents);
+                    // > 이미지 + 과거 기록 3개를 FastAPI /generate-blog에 전달.
+
+                    if (aiResponse != null) {
+                        return new AiDraftResponse(aiResponse.draft(), parseCategory(aiResponse.category()));
+                    }
+                }
+            }
         }
 
-        Category category = parseCategory(aiResponse.category());
-        // > FastAPI가 반환한 영문 문자열을 Category enum으로 변환.
+        // fallback: 기존 이미지 + 텍스트 기반 초안 생성 (/pipeline/generate)
+        AiResponse aiResponse = aiClient.generate(imageUrl, text, authorization);
+        if (aiResponse == null) {
+            return new AiDraftResponse(null, null);
+            // > AI 서버 장애 또는 stub 상태. 프론트에서 빈 값으로 처리.
+        }
+        return new AiDraftResponse(aiResponse.draft(), parseCategory(aiResponse.category()));
+    }
 
-        return new AiDraftResponse(aiResponse.draft(), category);
+    @Async
+    @Transactional
+    public void saveEmbeddingAsync(Long passportId, String content) {
+        // > 여권 저장 후 비동기로 호출. content를 임베딩해서 pgvector에 저장.
+        // > @Async: 여권 저장 API 응답 지연 방지 — Gemma 처리 시간을 백그라운드에서 처리.
+        // > 실패해도 여권 저장 자체에는 영향 없음 (try-catch로 격리).
+        try {
+            float[] embedding = aiClient.getEmbedding(content);
+            if (embedding == null) {
+                log.warn("임베딩 저장 skip: /get-embedding stub 상태 (passportId={})", passportId);
+                return;
+            }
+            passportRepository.updateEmbedding(passportId, toVectorString(embedding));
+            log.info("임베딩 저장 완료 (passportId={})", passportId);
+        } catch (Exception e) {
+            log.error("임베딩 저장 실패 (passportId={}): {}", passportId, e.getMessage());
+        }
+    }
+
+    private String toVectorString(float[] vector) {
+        // > float[] → "[0.1,-0.2,0.3,...]" 형식 변환.
+        // > pgvector CAST(:embedding AS vector) 구문에서 파싱 가능한 포맷.
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < vector.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(vector[i]);
+        }
+        return sb.append("]").toString();
     }
 
     private Category parseCategory(String categoryStr) {

--- a/src/main/java/com/kauniv/lightrip/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/WebSocketConfig.java
@@ -13,7 +13,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    > StompHandler: CONNECT 프레임에서 JWT 검증 후 userId를 세션에 저장
+    // > StompHandler: CONNECT 프레임에서 JWT 검증 후 userId를 세션에 저장
     private final StompHandler stompHandler;
 
     @Override
@@ -29,8 +29,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .withSockJS();
     }
 
-    > StompHandler를 인바운드 채널 인터셉터로 등록
-    > 클라이언트 → 서버 방향 모든 STOMP 프레임이 이 인터셉터를 통과함
+    // > StompHandler를 인바운드 채널 인터셉터로 등록
+    // > 클라이언트 → 서버 방향 모든 STOMP 프레임이 이 인터셉터를 통과함
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompHandler);

--- a/src/main/java/com/kauniv/lightrip/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/WebSocketConfig.java
@@ -13,7 +13,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    // StompHandler: CONNECT 프레임에서 JWT 검증 후 userId를 세션에 저장
+    > StompHandler: CONNECT 프레임에서 JWT 검증 후 userId를 세션에 저장
     private final StompHandler stompHandler;
 
     @Override
@@ -29,8 +29,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .withSockJS();
     }
 
-    // StompHandler를 인바운드 채널 인터셉터로 등록
-    // 클라이언트 → 서버 방향 모든 STOMP 프레임이 이 인터셉터를 통과함
+    > StompHandler를 인바운드 채널 인터셉터로 등록
+    > 클라이언트 → 서버 방향 모든 STOMP 프레임이 이 인터셉터를 통과함
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompHandler);

--- a/src/main/resources/db/migration/V8__add_passport_embedding.sql
+++ b/src/main/resources/db/migration/V8__add_passport_embedding.sql
@@ -1,0 +1,14 @@
+-- Passport 테이블에 pgvector 임베딩 컬럼 추가 (Issue #118)
+-- > embedding: EmbeddingGemma가 생성한 1536차원 벡터. content(여행 기록 텍스트)를 임베딩한 값.
+-- > RAG 초안 생성 시 유사한 과거 기록을 semantic search로 찾는 데 활용.
+-- > nullable: 여권 저장 후 비동기로 채워지므로 초기값 NULL 허용.
+ALTER TABLE public.passport ADD COLUMN IF NOT EXISTS embedding vector(1536);
+
+-- IVFFlat 인덱스 (코사인 유사도 기준)
+-- > HNSW 대신 IVFFlat 선택 이유: RDS db.t4g.micro 1GiB RAM 제약 — HNSW는 OOM 위험.
+-- > lists=20: 데모 규모(수백~수천 건) 기준 적정값. 20개 클러스터로 벡터 공간 분할.
+-- > vector_cosine_ops: 코사인 유사도 기반 검색 (의미적 유사성에 적합).
+CREATE INDEX IF NOT EXISTS idx_passport_embedding_ivfflat
+    ON public.passport
+    USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 20);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> 예시: Closes #118

## 개요
pgvector 기반 RAG 파이프라인을 구현
여권 저장 시 content를 임베딩해서 저장하고, AI 초안 생성 시 과거 유사 기록을 context로 주입해 개인화된 초안을 생성
AI 팀 `/get-embedding` 엔드포인트 완성 전까지는 stub(null 반환) 상태로 유지되며, 완성 시 `AiClient.java` 주석 해제만으로 활성화

## 변경 사항

### DB
- `V8__add_passport_embedding.sql`: `passport.embedding vector(1536)` 컬럼 추가
- IVFFlat 인덱스 (lists=20, cosine) — RDS db.t4g.micro 1GiB RAM 고려해 HNSW 대신 선택

### 핵심 로직
- `AiService.generateDraft()`: RAG 경로 추가 (text 있을 때 임베딩 → 유사 기록 검색 → 개인화 초안 / 실패 시 기존 경로 fallback)
- `AiService.saveEmbeddingAsync()`: `@Async` 비동기로 여권 저장 응답 지연 없이 임베딩 저장
- `PassportService.create()` → `PassportController.create()`: Authorization 헤더 체인 연결 (FastAPI JWT 검증 대응)

### 기타
- `MapSyncController`, `WebSocketConfig`, `TeamService`: `//` 누락으로 인한 컴파일 에러 수정
- `TeamService.updateLocationSharing()`: 누락 메서드 추가

## 테스트
- [ ] `./gradlew build -x test` 통과 확인
- [ ] `POST /api/v1/passports` 호출 시 Authorization 헤더 전달 정상 여부
- [ ] stub 상태에서 `saveEmbeddingAsync` warn 로그 출력 확인 (`AI /get-embedding stub — AI 팀 구현 대기 중`)
- [ ] `POST /api/v1/ai/draft?imageUrl=&text=` — RAG 경로 시도 후 fallback 동작 확인

## 참고
- AI 팀 `/get-embedding` 완성 후 `AiClient.java` 내 TODO 주석 해제만으로 RAG 활성화
- IVFFlat vs HNSW 선택 근거: HNSW는 1536차원 기준 인덱스 빌드 시 수백 MB RAM 소비 → RDS Free Tier OOM 위험

