### PR TITLE
feat: 친구 여권 탭 지역별 필터링 API 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/controller/FriendController.java
@@ -7,6 +7,7 @@ import com.kauniv.lightrip.domain.friend.dto.response.FriendResponse;
 import com.kauniv.lightrip.domain.friend.service.FriendService;
 import com.kauniv.lightrip.domain.passport.dto.response.DistrictResponse;
 import com.kauniv.lightrip.global.common.response.ApiResponse;
+import com.kauniv.lightrip.global.enums.District;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -92,16 +93,17 @@ public class FriendController {
         return ApiResponse.success(response);
     }
 
-    @Operation(summary = "친구 여권 목록 조회", description = "친구의 공개(PUBLIC) 여권 목록을 조회합니다. ACCEPTED 상태의 친구만 조회 가능하며, PRIVATE 여권은 제외됩니다.")
+    @Operation(summary = "친구 여권 목록 조회", description = "친구의 공개(PUBLIC) 여권 목록을 조회합니다. ACCEPTED 상태의 친구만 조회 가능하며, PRIVATE 여권은 제외됩니다. district 파라미터로 지역 필터링 가능합니다.")
     @GetMapping("/{friendId}/passports")
     public ApiResponse<List<FriendPassportResponse>> getFriendPassports(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "조회할 친구의 userId") @PathVariable Long friendId,
+            @Parameter(description = "지역 필터 (ex. MAPO, YONGSAN) — 미입력 시 전체 조회") @RequestParam(required = false) District district,
             @PageableDefault(size = 20, sort = "visitedAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         List<FriendPassportResponse> response =
-                friendService.getFriendPassports(userId, friendId, pageable);
-        return ApiResponse.success(response); 
+                friendService.getFriendPassports(userId, friendId, district, pageable);
+        return ApiResponse.success(response);
     }
 
     @Operation(summary = "친구 지도 조회", description = "친구의 공개(PUBLIC) 여권 기준으로 방문한 지역 목록을 조회합니다. ACCEPTED 상태의 친구만 조회 가능합니다.")

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -153,6 +153,7 @@ public class FriendService {
 
     public List<FriendPassportResponse> getFriendPassports(Long currentUserId,
                                                            Long friendId,
+                                                           District district,
                                                            Pageable pageable) {
         if (!friendRepository.isFriend(currentUserId, friendId)) {
             throw new BusinessException(ErrorCode.FRIEND_NOT_MEMBER);
@@ -161,7 +162,7 @@ public class FriendService {
         userRepository.findById(friendId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        return passportRepository.findPublicPassportsByUserId(friendId, pageable)
+        return passportRepository.findPublicPassportsByUserId(friendId, district, pageable)
                 .stream()
                 .map(FriendPassportResponse::from)
                 .toList();

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -227,9 +227,11 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
         LEFT JOIN FETCH p.images
         WHERE p.user.id = :userId
           AND p.visibility = com.kauniv.lightrip.global.enums.Visibility.PUBLIC
+          AND (:district IS NULL OR p.districtCategory = :district)
         ORDER BY p.visitedAt DESC, p.id DESC
         """)
     List<Passport> findPublicPassportsByUserId(@Param("userId") Long userId,
+                                               @Param("district") District district,
                                                Pageable pageable);
 
     List<Passport> findAllByTeam_Id(Long teamId);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #124

## 📝 작업 내용
친구 여권 목록 조회 API에 지역 필터링 기능 추가

**기존 파일 수정**
- `PassportRepository` — `findPublicPassportsByUserId`에 district 필터 파라미터 추가 (null이면 전체 조회)
- `FriendService` — `getFriendPassports`에 `District district` 파라미터 추가
- `FriendController` — `GET /{friendId}/passports?district={district}` 쿼리 파라미터 추가

| 파라미터 | 필수 | 설명 |
|---|---|---|
| district | X | District enum (ex. MAPO, YONGSAN) — 미입력 시 전체 조회 |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

