### PR TITLE
FEAT: pgvector RAG /get-embedding 활성화

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -15,6 +15,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -90,13 +91,23 @@ public class AiClient {
     }
 
     public float[] getEmbedding(String text, String authorization) {
-        // > 텍스트를 1536차원 벡터로 변환. pgvector 저장 및 RAG 검색에 사용.
-        // > authorization: FastAPI JWT 검증에 필요. generate()와 동일하게 전달.
-        // > [AI 팀 구현 후 추가] POST /get-embedding, body: {"text": text}, header: Authorization
-        // >   EmbeddingResponse.embedding() 반환값을 float[]로 return.
-        log.warn("AI /get-embedding stub — AI 팀 구현 대기 중 (textLength={})",
-                text != null ? text.length() : 0);
-        return null;
+        // > POST /get-embedding, body: {"texts": [text]} (배치 API — 단일 텍스트 1개 전송).
+        // > 응답: {"dim": 1536, "embeddings": [[...]]} → firstEmbedding()으로 float[] 추출.
+        // > authorization: FastAPI JWT 검증에 필요.
+        try {
+            EmbeddingResponse response = restClient.post()
+                    .uri(aiServerUrl + "/get-embedding")
+                    .header(HttpHeaders.AUTHORIZATION, authorization)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("texts", List.of(text)))
+                    .retrieve()
+                    .body(EmbeddingResponse.class);
+            return response != null ? response.firstEmbedding() : null;
+        } catch (Exception e) {
+            log.warn("AI /get-embedding 호출 실패 (textLength={}): {}",
+                    text != null ? text.length() : 0, e.getMessage());
+            return null;
+        }
     }
 
     public AiResponse generateWithContext(String imageUrl, List<String> context, String authorization) {

--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -102,7 +102,8 @@ public class AiClient {
                     .body(Map.of("texts", List.of(text)))
                     .retrieve()
                     .body(EmbeddingResponse.class);
-            return response != null ? response.firstEmbedding() : null;
+            float[] result = response != null ? response.firstEmbedding() : new float[0];
+            return result.length > 0 ? result : null;
         } catch (Exception e) {
             log.warn("AI /get-embedding 호출 실패 (textLength={}): {}",
                     text != null ? text.length() : 0, e.getMessage());

--- a/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
@@ -2,29 +2,47 @@ package com.kauniv.lightrip.global.ai.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 public record EmbeddingResponse(
-        @JsonProperty("embedding")
-        float[] embedding
-        // > FastAPI /get-embedding이 반환하는 1536차원 float 벡터.
-        // > pgvector 저장 및 유사도 검색에 사용.
+        @JsonProperty("dim")
+        int dim,
+        // > FastAPI /get-embedding 응답의 임베딩 차원수 (1536).
+        @JsonProperty("embeddings")
+        List<List<Float>> embeddings
+        // > 배치 입력 대응. 단일 텍스트 요청 시 embeddings[0]이 실제 벡터.
 ) {
-    // > record는 배열 필드를 참조로 비교하므로 내용 기반 비교로 오버라이드.
+    // > texts 배열의 첫 번째 임베딩을 float[]로 변환.
+    // > pgvector CAST("..." AS vector) 형식 변환에 사용.
+    public float[] firstEmbedding() {
+        if (embeddings == null || embeddings.isEmpty()) return null;
+        List<Float> first = embeddings.get(0);
+        if (first == null || first.isEmpty()) return null;
+        float[] result = new float[first.size()];
+        for (int i = 0; i < first.size(); i++) {
+            result[i] = first.get(i);
+        }
+        return result;
+    }
+
+    // > record의 List<List<Float>> 필드는 기본 equals가 참조 비교 → 내용 기반 비교로 오버라이드.
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof EmbeddingResponse other)) return false;
-        return Arrays.equals(embedding, other.embedding);
+        return dim == other.dim && Objects.equals(embeddings, other.embeddings);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(embedding);
+        return Objects.hash(dim, embeddings);
     }
 
     @Override
     public String toString() {
-        return "EmbeddingResponse{dim=" + (embedding != null ? embedding.length : 0) + "}";
+        int size = (embeddings != null && !embeddings.isEmpty() && embeddings.get(0) != null)
+                ? embeddings.get(0).size() : 0;
+        return "EmbeddingResponse{dim=" + dim + ", vectorLen=" + size + "}";
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/dto/EmbeddingResponse.java
@@ -16,9 +16,9 @@ public record EmbeddingResponse(
     // > texts 배열의 첫 번째 임베딩을 float[]로 변환.
     // > pgvector CAST("..." AS vector) 형식 변환에 사용.
     public float[] firstEmbedding() {
-        if (embeddings == null || embeddings.isEmpty()) return null;
+        if (embeddings == null || embeddings.isEmpty()) return new float[0];
         List<Float> first = embeddings.get(0);
-        if (first == null || first.isEmpty()) return null;
+        if (first == null || first.isEmpty()) return new float[0];
         float[] result = new float[first.size()];
         for (int i = 0; i < first.size(); i++) {
             result[i] = first.get(i);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #118

## 📝 작업 내용
AI 팀이 `/get-embedding` 엔드포인트를 완성함에 따라, 기존 stub으로 비워뒀던 임베딩 호출 코드를 실제 구현으로 교체.

**변경 사항**
기존 파일 수정
- `EmbeddingResponse.java` — AI 팀 실제 응답 스펙으로 변경. `float[] embedding` → `int dim` + `List<List<Float>> embeddings` (배치 API 대응). `firstEmbedding()` 편의 메서드 추가.
- `AiClient.java` — `getEmbedding()` stub 제거 → RestClient 실 구현. `POST /get-embedding`, body `{"texts": [text]}`, Authorization 헤더 포함. 예외 시 null 반환 (AiService fallback 경로 유지).

| 항목 | 내용 |
|---|---|
| FastAPI 요청 스펙 | `{"texts": ["..."]}` (배치 배열) |
| FastAPI 응답 스펙 | `{"dim": 1536, "embeddings": [[...]]}` |
| generateWithContext() | stub 유지 — AI 팀 `/generate-blog` 미완성 |
| fallback | getEmbedding() 실패 시 기존 `/pipeline/generate` 경로로 자동 전환 |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

