### PR TITLE
FEAT: references 파라미터 추가로 RAG 파이프라인 개선

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -29,10 +29,10 @@ public class AiClient {
     private String aiServerUrl;
     // > application.properties의 ai.server.url 값 주입.
 
-    public AiResponse generate(String imageUrl, String text, String authorization) {
+    public AiResponse generate(String imageUrl, String text, String references, String authorization) {
         // > CloudFront URL에서 이미지를 다운로드해서 FastAPI로 multipart 전송.
-        // > text: 사용자가 입력한 메모 텍스트. 없으면 image만 전송.
-        // > authorization: 사용자 JWT를 AI 서버로 그대로 전달.
+        // > text: 사용자 메모. references: pgvector 유사 기록 (없으면 생략). authorization: JWT 전달.
+
 
         // 1. 이미지 다운로드
         byte[] imageBytes;
@@ -70,7 +70,10 @@ public class AiClient {
         if (text != null) {
             body.add("text", text);
         }
-        // > 프론트가 전달한 메모 텍스트를 함께 전송. 없으면 image만 전송.
+        if (references != null) {
+            body.add("references", references);
+        }
+        // > text: 사용자 메모. references: pgvector 유사 기록. AI가 각각 별도 입력으로 활용.
 
         // 4. FastAPI 호출
         try {
@@ -111,13 +114,4 @@ public class AiClient {
         }
     }
 
-    public AiResponse generateWithContext(String imageUrl, List<String> context, String authorization) {
-        // > 이미지 + 과거 기록 context를 함께 전송해서 개인화된 초안 생성.
-        // > authorization: FastAPI JWT 검증에 필요. generate()와 동일하게 전달.
-        // > [AI 팀 구현 후 추가] POST /generate-blog, multipart: image + context list, header: Authorization
-        // >   generate()의 이미지 다운로드 + multipart 구성 패턴 그대로 재사용.
-        log.warn("AI /generate-blog stub — AI 팀 구현 대기 중 (contextSize={})",
-                context != null ? context.size() : 0);
-        return null;
-    }
 }

--- a/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
@@ -39,8 +39,9 @@ public class AiService {
                 // > 코사인 유사도 기준 상위 3개 과거 기록 텍스트 조회.
 
                 if (!similarContents.isEmpty()) {
-                    AiResponse aiResponse = aiClient.generateWithContext(imageUrl, similarContents, authorization);
-                    // > 이미지 + 과거 기록 3개를 FastAPI /generate-blog에 전달.
+                    String references = String.join("\n---\n", similarContents);
+                    // > 유사 기록 3개를 구분자로 연결 → FastAPI references 필드로 전달 (text와 별도 입력).
+                    AiResponse aiResponse = aiClient.generate(imageUrl, text, references, authorization);
 
                     if (aiResponse != null) {
                         return new AiDraftResponse(aiResponse.draft(), parseCategory(aiResponse.category()));
@@ -49,8 +50,8 @@ public class AiService {
             }
         }
 
-        // fallback: 기존 이미지 + 텍스트 기반 초안 생성 (/pipeline/generate)
-        AiResponse aiResponse = aiClient.generate(imageUrl, text, authorization);
+        // fallback: references 없이 이미지 + 텍스트만으로 초안 생성
+        AiResponse aiResponse = aiClient.generate(imageUrl, text, null, authorization);
         if (aiResponse == null) {
             return new AiDraftResponse(null, null);
             // > AI 서버 장애 또는 stub 상태. 프론트에서 빈 값으로 처리.


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #118

## 📝 작업 내용
AI 팀 요청에 따라 사용자 메모(text)와 pgvector 유사 기록(references)을 분리된 필드로 전달하도록 개선.

**변경 사항**
기존 파일 수정
- `AiClient.java` — generate()에 references 파라미터 추가, generateWithContext() stub 제거
- `AiService.java` — RAG 경로: 유사 기록 3개를 \n---\n으로 join해서 references로 분리 전달

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

