### PR TITLE
FIX: 친구 목록 조회 500 에러 수정

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
@@ -79,5 +79,13 @@ public record FriendResponse(
                     user.getProfileImg()
             );
         }
+
+        public static MutualFriendInfo fromRow(Object[] row) {
+            return new MutualFriendInfo(
+                    ((Number) row[0]).longValue(),
+                    (String) row[1],
+                    (String) row[2]
+            );
+        }
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
@@ -1,7 +1,6 @@
 package com.kauniv.lightrip.domain.friend.repository;
 
 import com.kauniv.lightrip.domain.friend.entity.Friend;
-import com.kauniv.lightrip.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -48,20 +47,21 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Long> findFriendUserIdsAmong(@Param("userId") Long userId,
                                       @Param("otherIds") List<Long> otherIds);
 
-    // 두 유저의 공통 친구 목록 조회
-    @Query("""
-            SELECT CASE WHEN f1.requester.id = :userA THEN f1.receiver ELSE f1.requester END
-            FROM Friend f1
-            WHERE f1.status = 'ACCEPTED'
-              AND (f1.requester.id = :userA OR f1.receiver.id = :userA)
-              AND (
-                CASE WHEN f1.requester.id = :userA THEN f1.receiver.id ELSE f1.requester.id END
-              ) IN (
-                SELECT CASE WHEN f2.requester.id = :userB THEN f2.receiver.id ELSE f2.requester.id END
-                FROM Friend f2
+    @Query(value = """
+            SELECT u.id, u.nickname, u.profile_img
+            FROM users u
+            WHERE u.id IN (
+                SELECT CASE WHEN f1.requester_id = :userA THEN f1.receiver_id ELSE f1.requester_id END
+                FROM friend f1
+                WHERE f1.status = 'ACCEPTED'
+                  AND (f1.requester_id = :userA OR f1.receiver_id = :userA)
+            )
+            AND u.id IN (
+                SELECT CASE WHEN f2.requester_id = :userB THEN f2.receiver_id ELSE f2.requester_id END
+                FROM friend f2
                 WHERE f2.status = 'ACCEPTED'
-                  AND (f2.requester.id = :userB OR f2.receiver.id = :userB)
-              )
-            """)
-    List<User> findMutualFriends(@Param("userA") Long userA, @Param("userB") Long userB);
+                  AND (f2.requester_id = :userB OR f2.receiver_id = :userB)
+            )
+            """, nativeQuery = true)
+    List<Object[]> findMutualFriends(@Param("userA") Long userA, @Param("userB") Long userB);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -128,7 +128,7 @@ public class FriendService {
                     // 공통 친구 목록 조회
                     List<FriendResponse.MutualFriendInfo> mutualFriends =
                             friendRepository.findMutualFriends(userId, target.getId()).stream()
-                                    .map(FriendResponse.MutualFriendInfo::from)
+                                    .map(FriendResponse.MutualFriendInfo::fromRow)
                                     .toList();
 
                     return FriendResponse.from(friend, target, passportCount, mutualFriends);
@@ -235,7 +235,7 @@ public class FriendService {
                     // 공통 친구 목록 조회
                     List<FriendResponse.MutualFriendInfo> mutualFriends =
                             friendRepository.findMutualFriends(userId, user.getId()).stream()
-                                    .map(FriendResponse.MutualFriendInfo::from)
+                                    .map(FriendResponse.MutualFriendInfo::fromRow)
                                     .toList();
 
                     return FriendResponse.ofUser(user, passportCount, mutualFriends);


### PR DESCRIPTION
## 📝 작업 내용
`GET /api/v1/friends` 호출 시 500 에러 발생하여 수정

**변경 사항**
기존 파일 수정
- `FriendRepository.java` — `findMutualFriends` JPQL → native query로 교체. Hibernate 7에서 CASE WHEN으로 엔티티 객체를 SELECT 시 `SingleTableEntityPersister cannot be cast to BasicValuedMapping` ClassCastException 발생하는 문제 수정. 반환 타입 `List<User>` → `List<Object[]>`.
- `FriendResponse.java` — `MutualFriendInfo.fromRow(Object[])` 매핑 메서드 추가
- `FriendService.java` — `findMutualFriends` 결과 매핑을 `fromRow()`로 변경

| 항목 | 내용 |
|---|---|
| 에러 원인 | Hibernate 7 JPQL CASE WHEN + 엔티티 객체 SELECT 비호환 |
| 수정 방법 | native query로 교체 |
| 영향 범위 | GET /api/v1/friends, GET /api/v1/friends/recommendations |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

