### PR TITLE
FIX: GET /api/v1/friends 500 에러 수정

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/repository/FriendRepository.java
@@ -48,19 +48,19 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
                                       @Param("otherIds") List<Long> otherIds);
 
     @Query(value = """
-            SELECT u.id, u.nickname, u.profile_img
+            SELECT u.user_id, u.nickname, u.profile_img
             FROM users u
-            WHERE u.id IN (
-                SELECT CASE WHEN f1.requester_id = :userA THEN f1.receiver_id ELSE f1.requester_id END
+            WHERE u.user_id IN (
+                SELECT CASE WHEN f1.request_id = :userA THEN f1.receiver_id ELSE f1.request_id END
                 FROM friend f1
                 WHERE f1.status = 'ACCEPTED'
-                  AND (f1.requester_id = :userA OR f1.receiver_id = :userA)
+                  AND (f1.request_id = :userA OR f1.receiver_id = :userA)
             )
-            AND u.id IN (
-                SELECT CASE WHEN f2.requester_id = :userB THEN f2.receiver_id ELSE f2.requester_id END
+            AND u.user_id IN (
+                SELECT CASE WHEN f2.request_id = :userB THEN f2.receiver_id ELSE f2.request_id END
                 FROM friend f2
                 WHERE f2.status = 'ACCEPTED'
-                  AND (f2.requester_id = :userB OR f2.receiver_id = :userB)
+                  AND (f2.request_id = :userB OR f2.receiver_id = :userB)
             )
             """, nativeQuery = true)
     List<Object[]> findMutualFriends(@Param("userA") Long userA, @Param("userB") Long userB);


### PR DESCRIPTION
## 🐛 버그 수정

| 항목 | 내용 |
|------|------|
| 대상 API | `GET /api/v1/friends` |
| 환경 | prod |
| 증상 | 수락된 친구가 있는 유저가 친구 목록 조회 시 500 에러 |

## 🔍 원인

공통 친구 조회 쿼리에서 두 가지 Hibernate 7 호환성 문제 발생

**1차 오류** — `ClassCastException: SingleTableEntityPersister cannot be cast to BasicValuedMapping`
- Hibernate 7에서 JPQL CASE WHEN이 엔티티 객체를 반환할 때 내부 캐스팅 실패
- JPQL → native query로 교체, 반환 타입 `List<User>` → `List<Object[]>` 변경

**2차 오류** — `PSQLException: column u.id does not exist`
- native query에서 잘못된 컬럼명 사용
- `u.id` → `u.user_id`, `f.requester_id` → `f.request_id` (실제 DB 스키마 기준)

## ✅ 수정 내용

- `FriendRepository.findMutualFriends()`: JPQL → native query 전환
- `FriendResponse.MutualFriendInfo`: `fromRow(Object[])` 메서드 추가
- `FriendService`: `::from` → `::fromRow` 매핑 변경