### PR TITLE
FEAT: 친구 목록 조회 응답에 도장(Stamp) 총 개수 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/dto/response/FriendResponse.java
@@ -16,6 +16,7 @@ public record FriendResponse(
         String status,
         LocalDateTime createdAt,
         Long passportCount,
+        Long stampCount,
         List<MutualFriendInfo> mutualFriends
 ) {
     public static FriendResponse from(Friend friend, User target) {
@@ -29,12 +30,14 @@ public record FriendResponse(
                 friend.getStatus().name(),
                 friend.getCreatedAt(),
                 null,
+                null,
                 null
         );
     }
 
     public static FriendResponse from(Friend friend, User target,
                                       Long passportCount,
+                                      Long stampCount,
                                       List<MutualFriendInfo> mutualFriends) {
         return new FriendResponse(
                 friend.getId(),
@@ -46,12 +49,14 @@ public record FriendResponse(
                 friend.getStatus().name(),
                 friend.getCreatedAt(),
                 passportCount,
+                stampCount,
                 mutualFriends
         );
     }
 
     public static FriendResponse ofUser(User user,
                                         Long passportCount,
+                                        Long stampCount,
                                         List<MutualFriendInfo> mutualFriends) {
         return new FriendResponse(
                 null,
@@ -63,6 +68,7 @@ public record FriendResponse(
                 null,
                 null,
                 passportCount,
+                stampCount,
                 mutualFriends
         );
     }

--- a/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/friend/service/FriendService.java
@@ -11,6 +11,7 @@ import com.kauniv.lightrip.domain.passport.dto.response.DistrictResponse;
 import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
 import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
 import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
+import com.kauniv.lightrip.domain.passport.repository.StampRepository;
 import com.kauniv.lightrip.domain.scrap.repository.ScrapRepository;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
@@ -36,6 +37,7 @@ public class FriendService {
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
     private final PassportRepository passportRepository;
+    private final StampRepository stampRepository;
     private final DistrictCoverRepository districtCoverRepository;
     private final ScrapRepository scrapRepository;
 
@@ -110,8 +112,15 @@ public class FriendService {
                         : f.getRequester().getId())
                 .toList();
 
-        // 도장 수 일괄 조회
+        // 여권 수 일괄 조회
         Map<Long, Long> passportCountMap = passportRepository.countByUserIds(targetIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        // 도장 수 일괄 조회
+        Map<Long, Long> stampCountMap = stampRepository.countByUserIds(targetIds).stream()
                 .collect(Collectors.toMap(
                         row -> (Long) row[0],
                         row -> (Long) row[1]
@@ -124,6 +133,7 @@ public class FriendService {
                             : friend.getRequester();
 
                     Long passportCount = passportCountMap.getOrDefault(target.getId(), 0L);
+                    Long stampCount = stampCountMap.getOrDefault(target.getId(), 0L);
 
                     // 공통 친구 목록 조회
                     List<FriendResponse.MutualFriendInfo> mutualFriends =
@@ -131,7 +141,7 @@ public class FriendService {
                                     .map(FriendResponse.MutualFriendInfo::fromRow)
                                     .toList();
 
-                    return FriendResponse.from(friend, target, passportCount, mutualFriends);
+                    return FriendResponse.from(friend, target, passportCount, stampCount, mutualFriends);
                 })
                 .toList();
     }
@@ -148,7 +158,7 @@ public class FriendService {
         User user = userRepository.findByFriendCode(friendCode)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        return FriendResponse.ofUser(user, null, null);
+        return FriendResponse.ofUser(user, null, null, null);
     }
 
     public List<FriendPassportResponse> getFriendPassports(Long currentUserId,
@@ -222,8 +232,15 @@ public class FriendService {
             return List.of();
         }
 
-        // 도장 수 일괄 조회
+        // 여권 수 일괄 조회
         Map<Long, Long> passportCountMap = passportRepository.countByUserIds(selectedIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        // 도장 수 일괄 조회
+        Map<Long, Long> stampCountMap = stampRepository.countByUserIds(selectedIds).stream()
                 .collect(Collectors.toMap(
                         row -> (Long) row[0],
                         row -> (Long) row[1]
@@ -232,6 +249,7 @@ public class FriendService {
         return userRepository.findAllById(selectedIds).stream()
                 .map(user -> {
                     Long passportCount = passportCountMap.getOrDefault(user.getId(), 0L);
+                    Long stampCount = stampCountMap.getOrDefault(user.getId(), 0L);
 
                     // 공통 친구 목록 조회
                     List<FriendResponse.MutualFriendInfo> mutualFriends =
@@ -239,7 +257,7 @@ public class FriendService {
                                     .map(FriendResponse.MutualFriendInfo::fromRow)
                                     .toList();
 
-                    return FriendResponse.ofUser(user, passportCount, mutualFriends);
+                    return FriendResponse.ofUser(user, passportCount, stampCount, mutualFriends);
                 })
                 .toList();
     }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/StampRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/StampRepository.java
@@ -1,0 +1,19 @@
+package com.kauniv.lightrip.domain.passport.repository;
+
+import com.kauniv.lightrip.domain.passport.entity.Stamp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StampRepository extends JpaRepository<Stamp, Long> {
+
+    @Query("""
+    SELECT s.passport.user.id, COUNT(s)
+    FROM Stamp s
+    WHERE s.passport.user.id IN :userIds
+    GROUP BY s.passport.user.id
+    """)
+    List<Object[]> countByUserIds(@Param("userIds") List<Long> userIds);
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #141

## 📝 작업 내용
`GET /api/v1/friends` 응답에 친구의 도장(Stamp) 총 개수(`stampCount`) 필드를 추가합니다.

**신규 생성**
- `StampRepository` — 여러 유저의 도장 수 일괄 조회 쿼리 추가 (`countByUserIds`)

**기존 파일 수정**
- `FriendResponse` — `stampCount` 필드 추가, 팩토리 메서드 3개 업데이트
- `FriendService` — `StampRepository` 주입, `getFriends()` / `getRecommendedFriends()` 에 stamp 수 일괄 조회 추가

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

