### PR TITLE
FIX: Redis 장애 시 블랙리스트 조회 fail-open 처리 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/redis/service/RedisService.java
+++ b/src/main/java/com/kauniv/lightrip/global/redis/service/RedisService.java
@@ -1,6 +1,7 @@
 package com.kauniv.lightrip.global.redis.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -9,6 +10,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisService {
@@ -38,7 +40,13 @@ public class RedisService {
     }
 
     public boolean isBlacklisted(String accessToken) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken));
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken));
+        } catch (Exception e) {
+            log.warn("Redis 블랙리스트 조회 실패 — fail-open 처리 (token prefix={}...): {}",
+                    accessToken.length() > 10 ? accessToken.substring(0, 10) : accessToken, e.getMessage());
+            return false;
+        }
     }
 
     public void saveRefreshToken(Long userId, String refreshToken, long expirationMs) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #146

## 📝 작업 내용
Redis 장애 시 JWT 블랙리스트 조회에서 예외가 발생해 모든 인증 요청이 차단되는 문제 수정.
예외 발생 시 `false`를 반환해 요청을 통과시키는 fail-open 정책으로 변경.

**변경 사항**
기존 파일 수정
- `RedisService.java` — `isBlacklisted()` try-catch 추가, Redis 예외 시 false 반환 + 경고 로그

| 정책 | 변경 전 | 변경 후 |
|---|---|---|
| Redis 장애 시 | 예외 발생 → 인증 전체 차단 | false 반환 → 요청 통과 |
| 로그 | 없음 | warn 레벨 로그 출력 |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

