### PR TITLE
FIX: 팀 리더 탈퇴 시 팀 삭제되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -236,6 +236,10 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
 
     List<Passport> findAllByTeam_Id(Long teamId);
 
+    @Modifying
+    @Query("UPDATE Passport p SET p.team = null WHERE p.team.id = :teamId")
+    void clearTeamReference(@Param("teamId") Long teamId);
+
     @Query("""
     SELECT p.user.id, COUNT(p)
     FROM Passport p

--- a/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
@@ -2,6 +2,9 @@ package com.kauniv.lightrip.domain.team.repository;
 
 import com.kauniv.lightrip.domain.team.entity.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +21,8 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
     // 유저가 속한 팀 조회 (유저당 팀 1개)
     Optional<TeamMember> findByUser_Id(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM TeamMember tm WHERE tm.team.id = :teamId")
+    void deleteAllByTeam_Id(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -12,6 +12,7 @@ import com.kauniv.lightrip.domain.team.entity.Team;
 import com.kauniv.lightrip.domain.team.entity.TeamMember;
 import com.kauniv.lightrip.domain.team.repository.TeamMemberRepository;
 import com.kauniv.lightrip.domain.team.repository.TeamRepository;
+import com.kauniv.lightrip.domain.passport.repository.PassportRepository;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
@@ -34,6 +35,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final UserRepository userRepository;
+    private final PassportRepository passportRepository;
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
 
@@ -109,7 +111,11 @@ public class TeamService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_MEMBER));
 
         if (member.getRole() == TeamMember.Role.LEADER) {
-            throw new BusinessException(ErrorCode.TEAM_LEADER_CANNOT_LEAVE);
+            // > LEADER 탈퇴 = 팀 해산. passport.team_id FK 제약 때문에 먼저 null 처리 후 삭제.
+            passportRepository.clearTeamReference(teamId);
+            teamMemberRepository.deleteAllByTeam_Id(teamId);
+            teamRepository.delete(member.getTeam());
+            return;
         }
 
         teamMemberRepository.delete(member);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #148

## 📝 작업 내용

팀 리더가 탈퇴 시 예외를 던지던 로직을 팀 해산으로 변경

**기존 파일 수정**
- `TeamService` — LEADER 탈퇴 시 팀 해산 처리 (passport null → 멤버 전체 삭제 → 팀 삭제), MEMBER 탈퇴는 기존 동일
- `TeamMemberRepository` — `deleteAllByTeam_Id()` bulk delete 쿼리 추가
- `PassportRepository` — `clearTeamReference()` bulk update 쿼리 추가 (팀 삭제 전 FK null 처리)

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

