### PR TITLE
FEAT: 여권 등록시 테마도 함께 등록 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportCreateRequest.java
@@ -133,7 +133,15 @@ public record PassportCreateRequest(
                 nullable = true,
                 example = "null"
         )
-        Long teamId
+        Long teamId,
+
+        @Schema(
+                description = "[선택] 테마 색상 RGB 값. 생략 또는 null 허용. 예: \"255,87,51\"",
+                nullable = true,
+                example = "255,87,51"
+        )
+        @Size(max = 30)
+        String theme
 ) {
         public Visibility visibilityOrDefault() {
                 return visibility == null ? Visibility.PUBLIC : visibility;

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportUpdateRequest.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/request/PassportUpdateRequest.java
@@ -42,5 +42,9 @@ public record PassportUpdateRequest(
 
         @Schema(description = "음악 아티스트")
         @Size(max = 100)
-        String musicArtist
+        String musicArtist,
+
+        @Schema(description = "테마 색상 RGB 값. 생략 또는 null 허용. 예: \"255,87,51\"", nullable = true, example = "255,87,51")
+        @Size(max = 30)
+        String theme
 ) {}

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/FeedPassportResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/FeedPassportResponse.java
@@ -37,7 +37,10 @@ public record FeedPassportResponse(
         boolean isLiked,
         boolean isScrapped,
         BigDecimal distanceKm,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+
+        @Schema(description = "테마 색상 RGB 값. 없으면 null", example = "255,87,51", nullable = true)
+        String theme
 ) {
     public static FeedPassportResponse of(
             Passport p,
@@ -73,7 +76,8 @@ public record FeedPassportResponse(
                 likedIds.contains(p.getId()),
                 scrappedIds.contains(p.getId()),
                 distanceKm,
-                p.getCreatedAt()
+                p.getCreatedAt(),
+                p.getTheme()
         );
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportListResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportListResponse.java
@@ -42,7 +42,10 @@ public record PassportListResponse(
         Long likeCount,
 
         @Schema(description = "스크랩 수", example = "5")
-        Long scrapCount
+        Long scrapCount,
+
+        @Schema(description = "테마 색상 RGB 값. 없으면 null", example = "255,87,51", nullable = true)
+        String theme
 ) {
     public static PassportListResponse from(Passport p) {
         String thumbnail = p.getImages().isEmpty()
@@ -60,7 +63,8 @@ public record PassportListResponse(
                 p.getVisitedAt(),
                 p.getVisibility(),
                 p.getLikeCount(),
-                p.getScrapCount()
+                p.getScrapCount(),
+                p.getTheme()
         );
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/dto/response/PassportResponse.java
@@ -38,7 +38,10 @@ public record PassportResponse(
         LocalDateTime updatedAt,
 
         @Schema(description = "지역 커버 ID (커버 변경 시 사용). 커버가 없으면 null")
-        Long coverId
+        Long coverId,
+
+        @Schema(description = "테마 색상 RGB 값. 없으면 null", example = "255,87,51", nullable = true)
+        String theme
 ) {
     public static PassportResponse from(Passport p) {
         return from(p, null);
@@ -75,7 +78,8 @@ public record PassportResponse(
                 stamps,
                 p.getCreatedAt(),
                 p.getUpdatedAt(),
-                coverId
+                coverId,
+                p.getTheme()
         );
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/Passport.java
@@ -106,6 +106,9 @@ public class Passport {
     @Column(name = "music_artist", length = 100)
     private String musicArtist;
 
+    @Column(name = "theme", length = 30)
+    private String theme;
+
     @Column(name = "like_count", nullable = false)
     @Builder.Default
     private Long likeCount = 0L;
@@ -124,7 +127,7 @@ public class Passport {
 
     public void update(String content, String spaceName, Category category,
                        District districtCategory, Visibility visibility,
-                       String musicTitle, String musicArtist) {
+                       String musicTitle, String musicArtist, String theme) {
         this.content = content;
         this.spaceName = spaceName;
         this.category = category;
@@ -132,6 +135,7 @@ public class Passport {
         this.visibility = visibility;
         this.musicTitle = musicTitle;
         this.musicArtist = musicArtist;
+        this.theme = theme;
     }
 
     public void replaceImages(List<String> imageUrls) {

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -99,6 +99,7 @@ public class PassportService {
                 .visibility(req.visibilityOrDefault())
                 .musicTitle(req.musicTitle())
                 .musicArtist(req.musicArtist())
+                .theme(req.theme())
                 .build();
 
         passportRepository.save(passport);
@@ -134,7 +135,7 @@ public class PassportService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
         validateUpdatePermission(passport, userId);
         passport.update(req.content(), req.spaceName(), req.category(),
-                req.districtCategory(), req.visibility(), req.musicTitle(), req.musicArtist());
+                req.districtCategory(), req.visibility(), req.musicTitle(), req.musicArtist(), req.theme());
         passport.replaceImages(req.imageUrls());
         return PassportResponse.from(passport);
     }

--- a/src/main/resources/db/migration/V10__add_passport_theme.sql
+++ b/src/main/resources/db/migration/V10__add_passport_theme.sql
@@ -1,0 +1,1 @@
+ALTER TABLE passport ADD COLUMN theme VARCHAR(30);


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #151 

## 📝 작업 내용

여권(Passport)에 테마 색상 필드(`theme`) 추가

- `V10__add_passport_theme.sql` — `passport` 테이블에 `theme VARCHAR(30)` 컬럼 추가 (nullable)
- `Passport` 엔티티 — `theme` 필드 추가, `update()` 메서드에 `theme` 파라미터 추가
- `PassportCreateRequest` / `PassportUpdateRequest` — 선택 필드 `theme` 추가 (미입력 시 `null`)
- `PassportResponse` / `PassportListResponse` / `FeedPassportResponse` — `theme` 반환 추가 (`null` 허용)
- `PassportService` — `create()` 빌더 및 `update()` 호출에 `theme` 연결

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.