### PR TITLE
FEAT: ECS Fargate 전환용 Terraform IaC 코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ tunnel.bat
 # k6 결과 파일
 k6/before.json
 k6/after.json
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+.terraform.lock.hcl

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,63 @@
+resource "aws_lb" "api" {
+  name               = "lightrip-${var.environment}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.subnet_ids
+
+  # WebSocket 연결 유지 — GPS 실시간 위치 공유용 (Redis TTL 5분과 동일)
+  idle_timeout = 300
+
+  tags = { Name = "lightrip-${var.environment}-alb" }
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "lightrip-${var.environment}-tg"
+  port        = var.app_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/actuator/health"
+    protocol            = "HTTP"
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = { Name = "lightrip-${var.environment}-tg" }
+}
+
+# HTTPS 리스너 — ACM 인증서로 SSL 종단 (현재 Nginx + Let's Encrypt를 대체)
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.acm_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+
+# HTTP -> HTTPS 리다이렉트
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,6 @@
+# 기존 VPC를 "참조"만 함 — Terraform이 관리(변경/삭제)하지 않음
+data "aws_vpc" "main" {
+  id = var.vpc_id
+}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -2,8 +2,8 @@ environment = "dev"
 
 # TODO: prod.tfvars와 동일한 서브넷 사용 가능
 subnet_ids = [
-  "subnet-xxxxxxxxxxxxxxxxx",
-  "subnet-yyyyyyyyyyyyyyyyy",
+  "subnet-02dd370f201c22443",
+  "subnet-0ccf2d37ff8ee3fcf",
 ]
 
 task_cpu      = 256 # 0.25 vCPU

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,0 +1,12 @@
+environment = "dev"
+
+# TODO: prod.tfvars와 동일한 서브넷 사용 가능
+subnet_ids = [
+  "subnet-xxxxxxxxxxxxxxxxx",
+  "subnet-yyyyyyyyyyyyyyyyy",
+]
+
+task_cpu      = 256 # 0.25 vCPU
+task_memory   = 512 # 0.5GB
+desired_count = 1
+app_port      = 8080

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,29 @@
+resource "aws_ecr_repository" "api" {
+  name                 = "lightrip-api-${var.environment}"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = { Name = "lightrip-${var.environment}-ecr" }
+}
+
+# 최근 10개만 보관, 나머지 자동 삭제 — ECR 스토리지 비용 절감
+resource "aws_ecr_lifecycle_policy" "api" {
+  repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 10 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 10
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,109 @@
+resource "aws_ecs_cluster" "main" {
+  name = "lightrip-${var.environment}"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = { Name = "lightrip-${var.environment}-cluster" }
+}
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/lightrip-${var.environment}"
+  retention_in_days = 30
+
+  tags = { Name = "lightrip-${var.environment}-logs" }
+}
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "lightrip-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name  = "lightrip-api"
+    image = "${aws_ecr_repository.api.repository_url}:latest"
+
+    portMappings = [{
+      containerPort = var.app_port
+      protocol      = "tcp"
+    }]
+
+    environment = [
+      { name = "DB_HOST", value = var.db_host },
+      { name = "DB_NAME", value = "lightrip" },
+      { name = "DB_USERNAME", value = "lightrip" },
+      { name = "DDL_AUTO", value = "none" },
+      { name = "SHOW_SQL", value = "false" },
+      { name = "FLYWAY_ENABLED", value = "true" },
+      { name = "DEEP_LINK_SCHEME", value = "lightrip" },
+      { name = "REDIS_HOST", value = aws_elasticache_cluster.redis.cache_nodes[0].address },
+      { name = "AWS_REGION", value = var.aws_region },
+      { name = "AWS_S3_BUCKET", value = "lightrip-s3" },
+      { name = "CLOUDFRONT_DOMAIN", value = "cdn.lightrip.cloud" },
+      { name = "SPRING_PROFILES_ACTIVE", value = var.environment },
+    ]
+
+    secrets = [
+      { name = "DB_PASSWORD", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:DB_PASSWORD::" },
+      { name = "JWT_SECRET", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:JWT_SECRET::" },
+      { name = "KAKAO_REST_API_KEY", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:KAKAO_REST_API_KEY::" },
+      { name = "KAKAO_CLIENT_SECRET", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:KAKAO_CLIENT_SECRET::" },
+      { name = "TOSS_SECRET_KEY", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:TOSS_SECRET_KEY::" },
+      { name = "AI_SERVER_API_KEY", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:AI_SERVER_API_KEY::" },
+      { name = "SENTRY_DSN", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:SENTRY_DSN::" },
+      { name = "SENTRY_AUTH_TOKEN", valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:SENTRY_AUTH_TOKEN::" },
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.ecs.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "ecs"
+      }
+    }
+  }])
+
+  tags = { Name = "lightrip-${var.environment}-task" }
+}
+
+resource "aws_ecs_service" "api" {
+  name            = "lightrip-${var.environment}-api"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [aws_security_group.ecs_task.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "lightrip-api"
+    container_port   = var.app_port
+  }
+
+  # 배포 실패 시 자동 롤백
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  # GitHub Actions가 update-service로 새 이미지 배포 — Terraform이 되돌리지 않도록
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  depends_on = [aws_lb_listener.https]
+
+  tags = { Name = "lightrip-${var.environment}-service" }
+}

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,0 +1,20 @@
+resource "aws_elasticache_subnet_group" "redis" {
+  name       = "lightrip-${var.environment}-redis"
+  subnet_ids = var.subnet_ids
+
+  tags = { Name = "lightrip-${var.environment}-redis-subnet" }
+}
+
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = "lightrip-${var.environment}"
+  engine               = "redis"
+  engine_version       = "7.1"
+  node_type            = var.elasticache_node_type
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.redis.name
+  security_group_ids   = [aws_security_group.elasticache.id]
+
+  tags = { Name = "lightrip-${var.environment}-redis" }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,69 @@
+# Task Execution Role — ECS 에이전트가 사용 (ECR pull, CloudWatch 로그, Secrets Manager 읽기)
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "lightrip-${var.environment}-ecs-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_base" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_secrets_read" {
+  name = "secrets-read"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = [aws_secretsmanager_secret.app_secrets.arn]
+    }]
+  })
+}
+
+# Task Role — 앱 컨테이너가 런타임에 사용 (S3 접근)
+# 현재 .env의 AWS_ACCESS_KEY_ID/SECRET_ACCESS_KEY를 대체
+resource "aws_iam_role" "ecs_task" {
+  name = "lightrip-${var.environment}-ecs-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "ecs_s3_access" {
+  name = "s3-access"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        "arn:aws:s3:::lightrip-s3",
+        "arn:aws:s3:::lightrip-s3/*"
+      ]
+    }]
+  })
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # 마이그레이션 시점에 S3 버킷 생성 후 주석 해제
+  # State를 S3에 저장해야 팀원 간 공유 + 동시 수정 방지 가능
+  # backend "s3" {
+  #   bucket         = "lightrip-terraform-state"
+  #   key            = "ecs/terraform.tfstate"
+  #   region         = "ap-northeast-2"
+  #   encrypt        = true
+  # }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,29 @@
+output "alb_dns_name" {
+  description = "ALB DNS — Cloudflare에서 api.lightrip.cloud CNAME을 이 값으로 변경"
+  value       = aws_lb.api.dns_name
+}
+
+output "ecr_repository_url" {
+  description = "ECR URL — GitHub Actions에서 docker push 대상"
+  value       = aws_ecr_repository.api.repository_url
+}
+
+output "ecs_cluster_name" {
+  description = "ECS 클러스터 이름 — aws ecs update-service에 사용"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_service_name" {
+  description = "ECS 서비스 이름 — aws ecs update-service에 사용"
+  value       = aws_ecs_service.api.name
+}
+
+output "redis_endpoint" {
+  description = "ElastiCache Redis 엔드포인트"
+  value       = aws_elasticache_cluster.redis.cache_nodes[0].address
+}
+
+output "secrets_manager_arn" {
+  description = "Secrets Manager ARN — 시크릿 값 등록 시 참조"
+  value       = aws_secretsmanager_secret.app_secrets.arn
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -4,8 +4,8 @@ environment = "prod"
 # 라우팅 테이블에 igw-xxx가 있는 서브넷 = 퍼블릭
 # 최소 2개, 서로 다른 AZ 필수 (예: ap-northeast-2a, 2c)
 subnet_ids = [
-  "subnet-xxxxxxxxxxxxxxxxx",
-  "subnet-yyyyyyyyyyyyyyyyy",
+  "subnet-02dd370f201c22443",
+  "subnet-0ccf2d37ff8ee3fcf",
 ]
 
 task_cpu      = 512  # 0.5 vCPU

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,0 +1,14 @@
+environment = "prod"
+
+# TODO: VPC 콘솔 > 서브넷 > vpc-03baa8243e6af7bc4 필터
+# 라우팅 테이블에 igw-xxx가 있는 서브넷 = 퍼블릭
+# 최소 2개, 서로 다른 AZ 필수 (예: ap-northeast-2a, 2c)
+subnet_ids = [
+  "subnet-xxxxxxxxxxxxxxxxx",
+  "subnet-yyyyyyyyyyyyyyyyy",
+]
+
+task_cpu      = 512  # 0.5 vCPU
+task_memory   = 1024 # 1GB
+desired_count = 1
+app_port      = 8080

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,27 @@
+# .env의 시크릿을 Secrets Manager에 저장
+# apply 후 AWS 콘솔에서 CHANGE_ME를 실제 값으로 교체
+resource "aws_secretsmanager_secret" "app_secrets" {
+  name = "lightrip/${var.environment}/app-secrets"
+
+  tags = { Name = "lightrip-${var.environment}-secrets" }
+}
+
+resource "aws_secretsmanager_secret_version" "app_secrets" {
+  secret_id = aws_secretsmanager_secret.app_secrets.id
+
+  secret_string = jsonencode({
+    DB_PASSWORD         = "CHANGE_ME"
+    JWT_SECRET          = "CHANGE_ME"
+    KAKAO_REST_API_KEY  = "CHANGE_ME"
+    KAKAO_CLIENT_SECRET = "CHANGE_ME"
+    TOSS_SECRET_KEY     = "CHANGE_ME"
+    AI_SERVER_API_KEY   = "CHANGE_ME"
+    SENTRY_DSN          = "CHANGE_ME"
+    SENTRY_AUTH_TOKEN   = "CHANGE_ME"
+  })
+
+  # 콘솔에서 실제 값으로 교체한 뒤 terraform apply가 덮어쓰지 않도록
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -1,0 +1,87 @@
+# ALB 보안 그룹 — 외부에서 80/443만 허용
+resource "aws_security_group" "alb" {
+  name        = "lightrip-${var.environment}-alb-sg"
+  description = "ALB inbound HTTP/HTTPS"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "lightrip-${var.environment}-alb-sg" }
+}
+
+# ECS Task 보안 그룹 — ALB에서만 앱 포트 접근 허용
+resource "aws_security_group" "ecs_task" {
+  name        = "lightrip-${var.environment}-ecs-sg"
+  description = "ECS Task - ALB only"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = var.app_port
+    to_port         = var.app_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "lightrip-${var.environment}-ecs-sg" }
+}
+
+# ElastiCache 보안 그룹 — ECS Task에서만 6379 접근 허용
+resource "aws_security_group" "elasticache" {
+  name        = "lightrip-${var.environment}-redis-sg"
+  description = "ElastiCache - ECS Task only"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_task.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "lightrip-${var.environment}-redis-sg" }
+}
+
+# 기존 RDS 보안 그룹에 ECS Task 접근 허용 규칙 추가
+# 기존 SG를 "관리"하지 않고 규칙만 추가 — 다른 인바운드 규칙에 영향 없음
+resource "aws_security_group_rule" "rds_from_ecs" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = var.rds_security_group_id
+  source_security_group_id = aws_security_group.ecs_task.id
+  description              = "ECS Task -> RDS"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,69 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "environment" {
+  description = "배포 환경 (prod / dev)"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "기존 VPC ID"
+  type        = string
+  default     = "vpc-03baa8243e6af7bc4"
+}
+
+# ALB는 최소 2개 AZ의 서브넷이 필수
+# VPC 콘솔 > 서브넷 > vpc-03baa8243e6af7bc4 필터 > 라우팅 테이블에 igw-xxx가 있는 서브넷이 퍼블릭
+variable "subnet_ids" {
+  description = "퍼블릭 서브넷 ID 목록 (최소 2개, 서로 다른 AZ)"
+  type        = list(string)
+}
+
+variable "task_cpu" {
+  description = "Fargate Task CPU (256 = 0.25 vCPU, 512 = 0.5 vCPU)"
+  type        = number
+}
+
+variable "task_memory" {
+  description = "Fargate Task 메모리 (MB)"
+  type        = number
+}
+
+variable "app_port" {
+  description = "Spring Boot 앱 포트"
+  type        = number
+  default     = 8080
+}
+
+variable "desired_count" {
+  description = "ECS 서비스 Task 수"
+  type        = number
+  default     = 1
+}
+
+variable "db_host" {
+  description = "RDS 엔드포인트"
+  type        = string
+  default     = "lightrip-db.cbg2c2egkvme.ap-northeast-2.rds.amazonaws.com"
+}
+
+variable "rds_security_group_id" {
+  description = "기존 RDS 보안 그룹 ID — ECS 접근 허용 규칙 추가 대상"
+  type        = string
+  default     = "sg-0359d60e73c922ea2"
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM 인증서 ARN (*.lightrip.cloud)"
+  type        = string
+  default     = "arn:aws:acm:ap-northeast-2:423405486977:certificate/6d271c6f-9b07-40a6-a578-659ec48e1819"
+}
+
+variable "elasticache_node_type" {
+  description = "ElastiCache 노드 타입"
+  type        = string
+  default     = "cache.t4g.micro"
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #154

## 📝 작업 내용
ECS Fargate 재전환 시점에 즉시 적용 가능하도록 Terraform IaC 코드를 사전 작성한다.
현재 EC2 + Docker 환경은 유지하며, 실사용자 트래픽 기준(ADR-10)에 도달하는 시점에 apply한다.

**신규 생성**
- `terraform/main.tf` — Provider(ap-northeast-2), S3 Backend(주석 처리)
- `terraform/variables.tf` — 환경별 변수 (VPC ID, RDS 엔드포인트 등 기입 완료)
- `terraform/data.tf` — 기존 VPC 읽기 전용 참조 (import 없음)
- `terraform/iam.tf` — Task Execution Role + Task Role (S3 액세스 키 대체)
- `terraform/sg.tf` — ALB/ECS/ElastiCache 보안 그룹
- `terraform/ecr.tf` — 이미지 레지스트리 + 수명 주기 정책
- `terraform/alb.tf` — HTTPS(ACM) + HTTP 리다이렉트 + WebSocket idle_timeout 300s
- `terraform/ecs.tf` — Fargate Cluster + Task Definition + Service (Rolling Update)
- `terraform/elasticache.tf` — Redis 7.1 (cache.t4g.micro)
- `terraform/secrets.tf` — Secrets Manager (.env 시크릿 관리)
- `terraform/outputs.tf` — ALB DNS, ECR URL, 클러스터/서비스 이름
- `terraform/prod.tfvars` — 0.5 vCPU / 1GB
- `terraform/dev.tfvars` — 0.25 vCPU / 0.5GB

**기존 파일 수정**
- `.gitignore` — Terraform 관련 항목 추가
- `docs/CLAUDE.md` — ADR-10 기록, 비용 구조 실측값으로 수정
- `CLAUDE.md` — 기술 스택 및 현재 상태 요약 업데이트

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

