### PR TITLE
FEAT: 릴스 피드 인기순+시드 셔플 정렬 적용

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -206,7 +206,9 @@ public class PassportController {
     }
 
     @Operation(summary = "릴스형 여권 피드 조회",
-            description = "다른 사용자의 PUBLIC 여권을 인기순으로 조회합니다. 카테고리/지역/위치 필터 지원, 커서 기반 무한스크롤.")
+            description = "다른 사용자의 PUBLIC 여권을 인기순(+약간의 랜덤)으로 조회합니다. 카테고리/지역/위치 필터 지원, 커서 기반 무한스크롤. "
+                    + "seed를 보내면 인기순을 유지하면서 비슷한 점수끼리 섞여 매번 다른 순서가 됩니다. "
+                    + "무한스크롤 동안에는 같은 seed를 유지하고, 새로고침 시 새 seed를 생성하세요. 미입력 시 순수 인기순입니다.")
     @GetMapping("/feed")
     public ApiResponse<FeedCursorResponse<FeedPassportResponse>> getFeed(
             @AuthenticationPrincipal Long userId,
@@ -215,13 +217,14 @@ public class PassportController {
             @Parameter(description = "사용자 위도") @RequestParam(required = false) BigDecimal latitude,
             @Parameter(description = "사용자 경도") @RequestParam(required = false) BigDecimal longitude,
             @Parameter(description = "반경(km), 기본 5") @RequestParam(defaultValue = "5") int radius,
+            @Parameter(description = "셔플 시드 (피드 세션마다 동일 값 유지, 미입력 시 인기순)") @RequestParam(required = false) String seed,
             @Parameter(description = "커서 (마지막 여권 ID)") @RequestParam(required = false) Long cursor,
-            @Parameter(description = "커서 점수 (마지막 인기 점수)") @RequestParam(required = false) Long cursorScore,
+            @Parameter(description = "커서 점수 (마지막 응답의 nextCursorScore)") @RequestParam(required = false) Long cursorScore,
             @Parameter(description = "조회 개수, 기본 10") @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.success(
                 passportService.getFeed(userId, category, district, latitude, longitude,
-                        radius, cursor, cursorScore, size)
+                        radius, seed, cursor, cursorScore, size)
         );
     }
 

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -77,38 +77,46 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     long countByUser_Id(Long userId);
 
     @Query(value = """
-        SELECT p.passport_id
-        FROM passport p
-        WHERE p.user_id <> :userId
-          AND p.visibility = 'PUBLIC'
-          AND (CAST(:category AS varchar) IS NULL
-               OR p.category = CAST(:category AS varchar))
-          AND (CAST(:district AS varchar) IS NULL
-               OR p.district_category = CAST(:district AS varchar))
-          AND (
-            :latitude IS NULL OR :longitude IS NULL
-            OR ST_DWithin(
-                p.location::geography,
-                ST_SetSRID(ST_MakePoint(CAST(:longitude AS float), CAST(:latitude AS float)), 4326)::geography,
-                CAST(:radius AS float) * 1000
-            )
-          )
-          AND (
-            :cursor IS NULL OR :cursorScore IS NULL
-            OR (p.like_count * 2 + p.scrap_count * 3) < :cursorScore
-            OR ((p.like_count * 2 + p.scrap_count * 3) = :cursorScore
-                AND p.passport_id < :cursor)
-          )
-        ORDER BY (p.like_count * 2 + p.scrap_count * 3) DESC, p.passport_id DESC
+        SELECT t.passport_id, t.eff_score
+        FROM (
+            SELECT p.passport_id AS passport_id,
+                   (p.like_count * 2 + p.scrap_count * 3
+                    + CASE WHEN CAST(:seed AS varchar) IS NULL THEN 0
+                           ELSE (('x' || substr(md5(p.passport_id::text || CAST(:seed AS varchar)), 1, 8))::bit(32)::int % 5 + 5) % 5
+                      END) AS eff_score
+            FROM passport p
+            WHERE p.user_id <> :userId
+              AND p.visibility = 'PUBLIC'
+              AND (CAST(:category AS varchar) IS NULL
+                   OR p.category = CAST(:category AS varchar))
+              AND (CAST(:district AS varchar) IS NULL
+                   OR p.district_category = CAST(:district AS varchar))
+              AND (
+                :latitude IS NULL OR :longitude IS NULL
+                OR ST_DWithin(
+                    p.location::geography,
+                    ST_SetSRID(ST_MakePoint(CAST(:longitude AS float), CAST(:latitude AS float)), 4326)::geography,
+                    CAST(:radius AS float) * 1000
+                )
+              )
+        ) t
+        WHERE :cursor IS NULL OR :cursorScore IS NULL
+           OR t.eff_score < :cursorScore
+           OR (t.eff_score = :cursorScore AND t.passport_id < :cursor)
+        ORDER BY t.eff_score DESC, t.passport_id DESC
         LIMIT :limit
         """, nativeQuery = true)
-    List<Long> findFeedPassportIds(
+    // > eff_score = 인기점수(좋아요×2 + 스크랩×3) + 시드 기반 jitter(0~4).
+    // > seed 미입력 시 jitter=0 → 순수 인기순. seed 동일하면 페이지 간 순서 고정.
+    // > jitter 폭(현재 5)을 키우면 랜덤성이 강해짐.
+    List<Object[]> findFeedPassportIds(
             @Param("userId") Long userId,
             @Param("category") String category,
             @Param("district") String district,
             @Param("latitude") BigDecimal latitude,
             @Param("longitude") BigDecimal longitude,
             @Param("radius") int radius,
+            @Param("seed") String seed,
             @Param("cursor") Long cursor,
             @Param("cursorScore") Long cursorScore,
             @Param("limit") int limit

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -295,20 +295,22 @@ public class PassportService {
     public FeedCursorResponse<FeedPassportResponse> getFeed(
             Long userId, Category category, District district,
             BigDecimal latitude, BigDecimal longitude,
-            int radius, Long cursor, Long cursorScore, int size) {
+            int radius, String seed, Long cursor, Long cursorScore, int size) {
 
         validateLocation(latitude, longitude);
 
-        List<Long> candidateIds = passportRepository.findFeedPassportIds(
+        List<Object[]> rows = passportRepository.findFeedPassportIds(
                 userId, category != null ? category.name() : null,
                 district != null ? district.name() : null,
-                latitude, longitude, radius, cursor, cursorScore, size + 1
+                latitude, longitude, radius, seed, cursor, cursorScore, size + 1
         );
 
-        if (candidateIds.isEmpty()) return FeedCursorResponse.of(List.of(), false, null, null);
+        if (rows.isEmpty()) return FeedCursorResponse.of(List.of(), false, null, null);
 
-        boolean hasNext = candidateIds.size() > size;
-        if (hasNext) candidateIds = candidateIds.subList(0, size);
+        boolean hasNext = rows.size() > size;
+        if (hasNext) rows = rows.subList(0, size);
+
+        List<Long> candidateIds = rows.stream().map(r -> ((Number) r[0]).longValue()).toList();
 
         List<Passport> passports = passportRepository.findAllByIdsForFeed(candidateIds);
         Map<Long, Passport> passportMap = passports.stream().collect(Collectors.toMap(Passport::getId, p -> p));
@@ -329,10 +331,10 @@ public class PassportService {
 
         Long nextCursor = null;
         Long nextCursorScore = null;
-        if (hasNext && !content.isEmpty()) {
-            FeedPassportResponse last = content.get(content.size() - 1);
-            nextCursor = last.passportId();
-            nextCursorScore = last.popularityScore();
+        if (hasNext) {
+            Object[] lastRow = rows.get(rows.size() - 1);
+            nextCursor = ((Number) lastRow[0]).longValue();
+            nextCursorScore = ((Number) lastRow[1]).longValue();
         }
 
         return FeedCursorResponse.of(content, hasNext, nextCursor, nextCursorScore);


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> Closes #156 

## 📝 작업 내용
릴스형 여권 피드(GET /api/v1/passports/feed)를 인기순 + 약간의 랜덤으로 개선했습니다.

기존: 인기점수(좋아요×2 + 스크랩×3) 고정 정렬 → 매번 같은 순서
변경: 유효점수 = 인기점수 + 시드 기반 jitter(0~4)로 정렬 → 인기 콘텐츠는 위로 노출하되 비슷한 점수끼리는 매번 다르게 섞임
상세 변경

seed 쿼리 파라미터 추가 — 같은 seed면 페이지 간 순서 고정(무한스크롤 중복/누락 방지), 새로고침(새 seed) 시 재셔플. 미입력 시 기존 인기순 유지(하위호환)
커서가 유효점수 기준으로 동작하도록 피드 쿼리 반환값을 (id, eff_score)로 변경
getFeed 서비스/컨트롤러 시그니처에 seed 반영 및 Swagger 문서 갱신
변경 파일

PassportController / PassportService / PassportRepository

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

