### PR TITLE
FEAT: 팀 모드 여권 조회 및 내 팀 조회 API 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/controller/PassportController.java
@@ -127,12 +127,14 @@ public class PassportController {
     }
 
     @Operation(summary = "내 기록 지역 조회",
-            description = "내가 여권을 등록한 지역 목록을 조회합니다. 지역별 여권 수와 대표 이미지를 포함합니다.")
+            description = "내가 여권을 등록한 지역 목록을 조회합니다. 지역별 여권 수와 대표 이미지를 포함합니다. "
+                    + "teamId 입력 시 해당 팀의 여권 기준으로 조회합니다(팀 모드, 커버 정보는 없음).")
     @GetMapping("/districts/me")
     public ApiResponse<List<DistrictResponse>> getMyDistricts(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "팀 ID (팀 모드, 미입력 시 개인)") @RequestParam(required = false) Long teamId
     ) {
-        return ApiResponse.success(passportService.getMyDistricts(userId));
+        return ApiResponse.success(passportService.getMyDistricts(userId, teamId));
     }
 
     @Operation(
@@ -152,21 +154,24 @@ public class PassportController {
     @GetMapping("/me")
     public ApiResponse<CursorResponse<PassportListResponse>> getMyPassports(
             @AuthenticationPrincipal Long userId,
+            @Parameter(description = "팀 ID (팀 모드, 미입력 시 개인)") @RequestParam(required = false) Long teamId,
             @Parameter(description = "카테고리 필터 (선택)") @RequestParam(required = false) Category category,
             @Parameter(description = "지역 필터 (선택)") @RequestParam(required = false) District districtCategory,
             @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
             @Parameter(description = "한 페이지에 가져올 여권 수 (기본값: 10, 최대: 50)") @RequestParam(defaultValue = "10") int size
     ) {
-        return ApiResponse.success(passportService.getMyPassports(userId, category, districtCategory, cursor, size));
+        return ApiResponse.success(passportService.getMyPassports(userId, teamId, category, districtCategory, cursor, size));
     }
 
     @Operation(summary = "내 여권 통계 조회",
-            description = "내가 작성한 여권 수, 좋아요 누른 수, 스크랩한 수를 조회합니다.")
+            description = "내가 작성한 여권 수, 좋아요 누른 수, 스크랩한 수를 조회합니다. "
+                    + "teamId 입력 시 팀 모드: 팀 여권 수 + 팀 여권이 받은 좋아요/스크랩 합계를 반환합니다.")
     @GetMapping("/stats/me")
     public ApiResponse<PassportStatsResponse> getMyStats(
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "팀 ID (팀 모드, 미입력 시 개인)") @RequestParam(required = false) Long teamId
     ) {
-        return ApiResponse.success(passportService.getMyStats(userId));
+        return ApiResponse.success(passportService.getMyStats(userId, teamId));
     }
 
     @Operation(summary = "카테고리별 내 여권 조회",
@@ -176,10 +181,11 @@ public class PassportController {
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "카테고리 (CAFE, RESTAURANT, BAR, CULTURE, ACTIVITY, SHOPPING, NATURE, ETC)")
             @PathVariable Category category,
+            @Parameter(description = "팀 ID (팀 모드, 미입력 시 개인)") @RequestParam(required = false) Long teamId,
             @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
             @Parameter(description = "한 페이지에 가져올 여권 수 (기본값: 10)") @RequestParam(defaultValue = "10") int size
     ) {
-        return ApiResponse.success(passportService.getMyPassports(userId, category, null, cursor, size));
+        return ApiResponse.success(passportService.getMyPassports(userId, teamId, category, null, cursor, size));
     }
 
     @Operation(summary = "지역별 내 여권 상세 조회",
@@ -197,11 +203,12 @@ public class PassportController {
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "지역 카테고리 (MAPO, GANGNAM, YONGSAN 등)")
             @PathVariable District districtCategory,
+            @Parameter(description = "팀 ID (팀 모드, 미입력 시 개인)") @RequestParam(required = false) Long teamId,
             @Parameter(description = "커서 (이전 응답의 nextCursor 값). 첫 요청 시 생략") @RequestParam(required = false) Long cursor,
             @Parameter(description = "한 페이지에 가져올 여권 수 (기본값: 10)") @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.success(
-                passportService.getMyPassportDetailsByDistrict(userId, districtCategory, cursor, size)
+                passportService.getMyPassportDetailsByDistrict(userId, teamId, districtCategory, cursor, size)
         );
     }
 

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -30,11 +30,13 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     @Query("""
         SELECT p.districtCategory, COUNT(p)
         FROM Passport p
-        WHERE p.user.id = :userId
+        WHERE ((:teamId IS NULL AND p.user.id = :userId)
+            OR (:teamId IS NOT NULL AND p.team.id = :teamId))
         GROUP BY p.districtCategory
         ORDER BY COUNT(p) DESC
         """)
-    List<Object[]> countByUserIdGroupByDistrict(Long userId);
+    // > teamId 미입력 시 개인(userId) 기준, 입력 시 팀 전체 멤버 여권 기준 집계.
+    List<Object[]> countByUserIdGroupByDistrict(Long userId, Long teamId);
 
     @Query("""
         SELECT p.districtCategory, COUNT(p)
@@ -49,12 +51,15 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     @Query("""
         SELECT p FROM Passport p
         LEFT JOIN FETCH p.images
-        WHERE p.user.id = :userId
+        WHERE ((:teamId IS NULL AND p.user.id = :userId)
+            OR (:teamId IS NOT NULL AND p.team.id = :teamId))
           AND (:category IS NULL OR p.category = :category)
           AND (:districtCategory IS NULL OR p.districtCategory = :districtCategory)
         ORDER BY p.visitedAt DESC, p.id DESC
         """)
+    // > teamId 미입력 시 개인(userId), 입력 시 팀 전체 멤버 여권.
     List<Passport> findMyPassportsFirst(Long userId,
+                                        Long teamId,
                                         Category category,
                                         District districtCategory,
                                         Pageable pageable);
@@ -62,19 +67,31 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     @Query("""
         SELECT p FROM Passport p
         LEFT JOIN FETCH p.images
-        WHERE p.user.id = :userId
+        WHERE ((:teamId IS NULL AND p.user.id = :userId)
+            OR (:teamId IS NOT NULL AND p.team.id = :teamId))
           AND p.id < :cursor
           AND (:category IS NULL OR p.category = :category)
           AND (:districtCategory IS NULL OR p.districtCategory = :districtCategory)
         ORDER BY p.visitedAt DESC, p.id DESC
         """)
     List<Passport> findMyPassportsAfterCursor(Long userId,
+                                              Long teamId,
                                               Long cursor,
                                               Category category,
                                               District districtCategory,
                                               Pageable pageable);
 
     long countByUser_Id(Long userId);
+
+    long countByTeam_Id(Long teamId);
+
+    @Query("""
+        SELECT COUNT(p), COALESCE(SUM(p.likeCount), 0), COALESCE(SUM(p.scrapCount), 0)
+        FROM Passport p
+        WHERE p.team.id = :teamId
+        """)
+    // > 팀 통계: 팀 여권 수 + 팀 여권이 받은 좋아요/스크랩 합계.
+    List<Object[]> findTeamStats(Long teamId);
 
     @Query(value = """
         SELECT t.passport_id, t.eff_score

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -237,11 +237,22 @@ public class PassportService {
         }
     }
 
+    // ========== 팀 멤버십 검증 ==========
+    private void validateTeamMembership(Long teamId, Long userId) {
+        if (!teamMemberRepository.existsByTeam_IdAndUser_Id(teamId, userId)) {
+            throw new BusinessException(ErrorCode.TEAM_NOT_MEMBER);
+        }
+    }
+
     // ========== 내 기록 지역 조회 ==========
-    public List<DistrictResponse> getMyDistricts(Long userId) {
-        List<Object[]> counts = passportRepository.countByUserIdGroupByDistrict(userId);
-        Map<District, DistrictCover> coverMap = districtCoverRepository.findAllByUser_Id(userId).stream()
-                .collect(Collectors.toMap(DistrictCover::getDistrictCategory, c -> c));
+    public List<DistrictResponse> getMyDistricts(Long userId, Long teamId) {
+        if (teamId != null) validateTeamMembership(teamId, userId);
+        List<Object[]> counts = passportRepository.countByUserIdGroupByDistrict(userId, teamId);
+        // 커버는 개인(user) 단위로만 존재 → 팀 모드에선 커버 정보 없음
+        Map<District, DistrictCover> coverMap = (teamId == null)
+                ? districtCoverRepository.findAllByUser_Id(userId).stream()
+                    .collect(Collectors.toMap(DistrictCover::getDistrictCategory, c -> c))
+                : Map.of();
         return counts.stream()
                 .map(row -> {
                     District district = (District) row[0];
@@ -255,12 +266,13 @@ public class PassportService {
     }
 
     // ========== 내 여권 목록 조회 ==========
-    public CursorResponse<PassportListResponse> getMyPassports(Long userId, Category category,
+    public CursorResponse<PassportListResponse> getMyPassports(Long userId, Long teamId, Category category,
                                                                District districtCategory,
                                                                Long cursor, int size) {
+        if (teamId != null) validateTeamMembership(teamId, userId);
         List<Passport> passports = (cursor == null)
-                ? passportRepository.findMyPassportsFirst(userId, category, districtCategory, PageRequest.of(0, size + 1))
-                : passportRepository.findMyPassportsAfterCursor(userId, cursor, category, districtCategory, PageRequest.of(0, size + 1));
+                ? passportRepository.findMyPassportsFirst(userId, teamId, category, districtCategory, PageRequest.of(0, size + 1))
+                : passportRepository.findMyPassportsAfterCursor(userId, teamId, cursor, category, districtCategory, PageRequest.of(0, size + 1));
         boolean hasNext = passports.size() > size;
         if (hasNext) passports = passports.subList(0, size);
         Long nextCursor = hasNext ? passports.get(passports.size() - 1).getId() : null;
@@ -268,12 +280,13 @@ public class PassportService {
     }
 
     // ========== 지역별 내 여권 상세 목록 조회 ==========
-    public CursorResponse<PassportResponse> getMyPassportDetailsByDistrict(Long userId,
+    public CursorResponse<PassportResponse> getMyPassportDetailsByDistrict(Long userId, Long teamId,
                                                                           District districtCategory,
                                                                           Long cursor, int size) {
+        if (teamId != null) validateTeamMembership(teamId, userId);
         List<Passport> passports = (cursor == null)
-                ? passportRepository.findMyPassportsFirst(userId, null, districtCategory, PageRequest.of(0, size + 1))
-                : passportRepository.findMyPassportsAfterCursor(userId, cursor, null, districtCategory, PageRequest.of(0, size + 1));
+                ? passportRepository.findMyPassportsFirst(userId, teamId, null, districtCategory, PageRequest.of(0, size + 1))
+                : passportRepository.findMyPassportsAfterCursor(userId, teamId, cursor, null, districtCategory, PageRequest.of(0, size + 1));
         boolean hasNext = passports.size() > size;
         if (hasNext) passports = passports.subList(0, size);
         Long nextCursor = hasNext ? passports.get(passports.size() - 1).getId() : null;
@@ -281,7 +294,17 @@ public class PassportService {
     }
 
     // ========== 내 여권 통계 조회 ==========
-    public PassportStatsResponse getMyStats(Long userId) {
+    public PassportStatsResponse getMyStats(Long userId, Long teamId) {
+        if (teamId != null) {
+            validateTeamMembership(teamId, userId);
+            // 팀 통계: 팀 여권 수 + 팀 여권이 받은 좋아요/스크랩 합계
+            Object[] row = passportRepository.findTeamStats(teamId).get(0);
+            return new PassportStatsResponse(
+                    ((Number) row[0]).longValue(),
+                    ((Number) row[1]).longValue(),
+                    ((Number) row[2]).longValue()
+            );
+        }
         return new PassportStatsResponse(
                 passportRepository.countByUser_Id(userId),
                 likeRepository.countByUser_Id(userId),

--- a/src/main/java/com/kauniv/lightrip/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/controller/TeamController.java
@@ -4,6 +4,7 @@ import com.kauniv.lightrip.domain.team.dto.request.LocationSharingRequest;
 import com.kauniv.lightrip.domain.team.dto.request.TeamCreateRequest;
 import com.kauniv.lightrip.domain.team.dto.request.TeamJoinRequest;
 import com.kauniv.lightrip.domain.team.dto.response.LiveLocationResponse;
+import com.kauniv.lightrip.domain.team.dto.response.MyTeamResponse;
 import com.kauniv.lightrip.domain.team.dto.response.TeamMemberResponse;
 import com.kauniv.lightrip.domain.team.dto.response.TeamResponse;
 import com.kauniv.lightrip.domain.team.service.TeamService;
@@ -48,6 +49,14 @@ public class TeamController {
             @AuthenticationPrincipal Long userId,
             @RequestBody TeamJoinRequest req) {
         return ResponseEntity.ok(teamService.join(userId, req));
+    }
+
+    @Operation(summary = "내 팀 조회",
+            description = "로그인한 사용자가 소속된 팀 정보를 조회합니다. 팀 ID, 팀장, 전체 팀원 목록을 반환합니다. 소속된 팀이 없으면 404를 반환합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<MyTeamResponse> getMyTeam(
+            @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(teamService.getMyTeam(userId));
     }
 
     @Operation(summary = "팀 정보 조회", description = "팀 ID로 팀 기본 정보를 조회합니다.")

--- a/src/main/java/com/kauniv/lightrip/domain/team/dto/response/MyTeamResponse.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/dto/response/MyTeamResponse.java
@@ -1,0 +1,51 @@
+package com.kauniv.lightrip.domain.team.dto.response;
+
+import com.kauniv.lightrip.domain.team.entity.Team;
+import com.kauniv.lightrip.domain.team.entity.TeamMember;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "내 팀 조회 응답 (팀 ID + 팀장 + 팀원 목록)")
+public record MyTeamResponse(
+
+        @Schema(description = "팀 ID")
+        Long teamId,
+
+        @Schema(description = "팀 이름")
+        String teamName,
+
+        @Schema(description = "팀 코드")
+        String teamCode,
+
+        @Schema(description = "생성 일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "팀장 (role = LEADER)")
+        TeamMemberResponse leader,
+
+        @Schema(description = "전체 팀원 목록 (팀장 포함)")
+        List<TeamMemberResponse> members
+) {
+    public static MyTeamResponse of(Team team, List<TeamMember> members) {
+        List<TeamMemberResponse> memberResponses = members.stream()
+                .map(TeamMemberResponse::from)
+                .toList();
+
+        TeamMemberResponse leader = members.stream()
+                .filter(m -> m.getRole() == TeamMember.Role.LEADER)
+                .map(TeamMemberResponse::from)
+                .findFirst()
+                .orElse(null);
+
+        return new MyTeamResponse(
+                team.getId(),
+                team.getTeamName(),
+                team.getTeamCode(),
+                team.getCreatedAt(),
+                leader,
+                memberResponses
+        );
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -6,6 +6,7 @@ import com.kauniv.lightrip.domain.team.dto.request.LocationMessage;
 import com.kauniv.lightrip.domain.team.dto.request.TeamCreateRequest;
 import com.kauniv.lightrip.domain.team.dto.request.TeamJoinRequest;
 import com.kauniv.lightrip.domain.team.dto.response.LiveLocationResponse;
+import com.kauniv.lightrip.domain.team.dto.response.MyTeamResponse;
 import com.kauniv.lightrip.domain.team.dto.response.TeamMemberResponse;
 import com.kauniv.lightrip.domain.team.dto.response.TeamResponse;
 import com.kauniv.lightrip.domain.team.entity.Team;
@@ -94,6 +95,14 @@ public class TeamService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
         return TeamResponse.from(team);
+    }
+
+    public MyTeamResponse getMyTeam(Long userId) {
+        TeamMember membership = teamMemberRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_JOINED));
+        Team team = membership.getTeam();
+        List<TeamMember> members = teamMemberRepository.findAllByTeam_Id(team.getId());
+        return MyTeamResponse.of(team, members);
     }
 
     public List<TeamMemberResponse> getMembers(Long teamId) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)


Closes #159 

## 📝 작업 내용

프론트가 팀 상태일 때 팀 여권을 조회하고, 자신이 속한 팀 정보를 확인할 수 있도록 API를 추가했습니다.

### 1. 팀 모드 여권 조회 (`teamId` 파라미터 추가)
기존 여권 조회 계열 API에 `teamId` 쿼리 파라미터를 추가했습니다. **미입력 시 개인 여권(기존 동작 유지), 입력 시 해당 팀의 모든 멤버 여권**을 반환합니다.
- 대상: `GET /passports/me`, `/passports/districts/me`, `/passports/districts/{districtCategory}`, `/passports/categories/{category}`, `/passports/stats/me`
- `teamId` 입력 시 **팀 멤버십 검증** (비멤버는 `403 TEAM_NOT_MEMBER`)
- Repository 쿼리에 teamId 분기 추가 + 팀 통계 집계 쿼리 추가

### 2. 내 팀 조회 API 신규
- `GET /api/v1/teams/me` — 로그인 유저가 소속된 팀 정보 반환 (팀 ID, 팀장, 전체 팀원 목록)
- 소속 팀이 없으면 `404 TEAM_NOT_JOINED`

### 변경/추가 파일
- 변경: `PassportController`, `PassportService`, `PassportRepository`, `TeamController`, `TeamService`
- 신규: `MyTeamResponse`

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.
