### PR TITLE
FIX: Terraform SonarCloud IaC 이슈 수정

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -8,6 +8,12 @@ resource "aws_lb" "api" {
   # WebSocket 연결 유지 — GPS 실시간 위치 공유용 (Redis TTL 5분과 동일)
   idle_timeout = 300
 
+  access_logs {
+    bucket  = "lightrip-s3"
+    prefix  = "alb/${var.environment}"
+    enabled = true
+  }
+
   tags = { Name = "lightrip-${var.environment}-alb" }
 }
 

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,6 +1,7 @@
 resource "aws_ecr_repository" "api" {
   name                 = "lightrip-api-${var.environment}"
-  image_tag_mutability = "MUTABLE"
+  # > IMMUTABLE: 동일 태그로 덮어쓰기 불가 — CI/CD에서 :latest 대신 커밋 SHA 태그 사용 필요
+  image_tag_mutability = "IMMUTABLE"
   force_delete         = false
 
   image_scanning_configuration {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -92,7 +92,7 @@ resource "aws_ecs_service" "api" {
   network_configuration {
     subnets          = var.subnet_ids
     security_groups  = [aws_security_group.ecs_task.id]
-    assign_public_ip = true
+    assign_public_ip = true #NOSONAR — NAT Gateway($30+/월) 없이 ECR pull 하기 위한 의도적 설정 (ADR-1 비용 절감)
   }
 
   load_balancer {

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,3 +1,5 @@
+# ECS 클러스터 — prod/dev 각각 별도 클러스터로 분리
+# containerInsights: CloudWatch에 CPU/메모리/네트워크 메트릭 자동 수집
 resource "aws_ecs_cluster" "main" {
   name = "lightrip-${var.environment}"
 
@@ -9,6 +11,8 @@ resource "aws_ecs_cluster" "main" {
   tags = { Name = "lightrip-${var.environment}-cluster" }
 }
 
+# 현재 EC2의 CloudWatch Agent(/ec2/lightrip-server)와 별도로 ECS 전용 로그 그룹 생성
+# retention_in_days = 30: 로그 스토리지 비용 절감
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/lightrip-${var.environment}"
   retention_in_days = 30
@@ -16,6 +20,9 @@ resource "aws_cloudwatch_log_group" "ecs" {
   tags = { Name = "lightrip-${var.environment}-logs" }
 }
 
+# Task Definition — 컨테이너 스펙 선언
+# environment: 민감하지 않은 값 (DB 호스트, 리전 등)
+# secrets: Secrets Manager에서 런타임에 주입 — 평문 노출 없음
 resource "aws_ecs_task_definition" "api" {
   family                   = "lightrip-${var.environment}"
   requires_compatibilities = ["FARGATE"]
@@ -73,6 +80,8 @@ resource "aws_ecs_task_definition" "api" {
   tags = { Name = "lightrip-${var.environment}-task" }
 }
 
+# ECS 서비스 — Task를 항상 desired_count만큼 유지, ALB와 연결해 Rolling Update 수행
+# assign_public_ip = true: NAT Gateway 없이 ECR pull + 외부 API 호출 가능 (ADR-1 비용 절감 원칙 유지)
 resource "aws_ecs_service" "api" {
   name            = "lightrip-${var.environment}-api"
   cluster         = aws_ecs_cluster.main.id

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -18,5 +18,10 @@ resource "aws_elasticache_cluster" "redis" {
   subnet_group_name    = aws_elasticache_subnet_group.redis.name
   security_group_ids   = [aws_security_group.elasticache.id]
 
+  at_rest_encryption_enabled = true
+  # > transit_encryption_enabled 적용 시 Spring Boot Redis 클라이언트에 SSL 설정 필요
+  # > application.properties: spring.data.redis.ssl.enabled=true
+  transit_encryption_enabled = true
+
   tags = { Name = "lightrip-${var.environment}-redis" }
 }

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,3 +1,5 @@
+# EC2에 직접 설치된 Redis(현재 10.0.3.247:6379)를 대체 — JWT 블랙리스트 + Refresh Token + 실시간 위치 저장
+# ECS Task SG에서만 6379 접근 허용 (sg.tf의 elasticache SG 참조)
 resource "aws_elasticache_subnet_group" "redis" {
   name       = "lightrip-${var.environment}-redis"
   subnet_ids = var.subnet_ids


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #154

## 📝 작업 내용
SonarCloud IaC 분석에서 제기된 Terraform 보안 이슈 수정
**기존 파일 수정**
- `terraform/elasticache.tf` — `at_rest_encryption_enabled`, `transit_encryption_enabled` 활성화 (S6330, S6382)
- `terraform/ecr.tf` — `image_tag_mutability` MUTABLE → IMMUTABLE (S6335)
- `terraform/alb.tf` — `access_logs` 블록 추가, lightrip-s3 버킷으로 설정 (S6252)
- `terraform/ecs.tf` — `assign_public_ip = true` NOSONAR 처리 (S6321, NAT Gateway 미사용 ADR-1)

**apply 전 선행 작업**
| 항목 | 내용 |
|---|---|
| ECR IMMUTABLE | CI/CD에서 `:latest` 태그 → 커밋 SHA 태그로 교체 필요 |
| ElastiCache TLS | Spring Boot `spring.data.redis.ssl.enabled=true` 설정 필요 |
| ALB access_logs | `lightrip-s3` 버킷에 ALB 로깅 버킷 정책 추가 필요 |

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

