### PR TITLE
FIX: SonarCloud 정적 분석 이슈 수정

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/payment/service/PaymentService.java
@@ -21,6 +21,8 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -137,9 +139,10 @@ public class PaymentService {
             expiry = base.plusMonths(p.getProductType().getMonths());
         }
 
-        LocalDateTime now = LocalDateTime.now();
-        boolean premium = expiry != null && expiry.isAfter(now);
-        Long daysLeft = premium ? ChronoUnit.DAYS.between(now, expiry) : null;
+        ZoneId zone = ZoneId.of("Asia/Seoul");
+        ZonedDateTime now = ZonedDateTime.now(zone);
+        boolean premium = expiry != null && expiry.atZone(zone).isAfter(now);
+        Long daysLeft = premium ? ChronoUnit.DAYS.between(now, expiry.atZone(zone)) : null;
 
         return PremiumStatusResponse.of(premium, expiry, daysLeft);
     }

--- a/src/main/java/com/kauniv/lightrip/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/ranking/service/RankingService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -79,7 +80,7 @@ public class RankingService {
         rankingRepository.deleteAllInBatch();
 
         // 2. 이번 주 월요일 00:00 계산
-        LocalDateTime weekStartAt = LocalDateTime.now()
+        LocalDateTime weekStartAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
                 .with(DayOfWeek.MONDAY)
                 .with(LocalTime.MIDNIGHT);
 

--- a/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/AiClient.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,7 @@ public class AiClient {
                     .toEntity(byte[].class);
             // > cdn.lightrip.cloud URL로 이미지 byte[] 다운로드.
             imageBytes = imageResponse.getBody();
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.warn("AI 서버: 이미지 다운로드 실패 - {} : {}", imageUrl, e.getMessage());
             return null;
         }
@@ -91,7 +92,7 @@ public class AiClient {
                     .body(AiResponse.class);
             // > POST /pipeline/generate 호출 후 AiResponse로 역직렬화.
             // > AI 서버는 Authorization 헤더의 JWT를 검증.
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.warn("AI /pipeline/generate 호출 실패: {}", e.getMessage());
             return null;
             // > FastAPI 500 등 오류 시 null 반환 → AiService에서 빈 초안으로 처리.
@@ -113,7 +114,7 @@ public class AiClient {
                     .body(EmbeddingResponse.class);
             float[] result = response != null ? response.firstEmbedding() : new float[0];
             return result.length > 0 ? result : null;
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.warn("AI /get-embedding 호출 실패 (textLength={}): {}",
                     text != null ? text.length() : 0, e.getMessage());
             return null;

--- a/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
+++ b/src/main/java/com/kauniv/lightrip/global/ai/service/AiService.java
@@ -74,7 +74,7 @@ public class AiService {
             }
             passportRepository.updateEmbedding(passportId, toVectorString(embedding));
             log.info("임베딩 저장 완료 (passportId={})", passportId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("임베딩 저장 실패 (passportId={}): {}", passportId, e.getMessage());
         }
     }

--- a/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.kauniv.lightrip.global.auth.controller;
 
 import com.kauniv.lightrip.global.auth.dto.TokenResponse;
 import com.kauniv.lightrip.global.auth.service.AuthService;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,9 @@ public class AuthController {
     public ResponseEntity<Void> logout(
             @AuthenticationPrincipal Long userId,
             @RequestHeader("Authorization") String bearerToken) {
+        if (!bearerToken.startsWith("Bearer ")) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
         String accessToken = bearerToken.substring(7);
         authService.logout(userId, accessToken);
         return ResponseEntity.ok().build();
@@ -44,6 +49,9 @@ public class AuthController {
     public ResponseEntity<Void> withdraw(
             @AuthenticationPrincipal Long userId,
             @RequestHeader("Authorization") String bearerToken) {
+        if (!bearerToken.startsWith("Bearer ")) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
         String accessToken = bearerToken.substring(7);
         authService.withdraw(userId, accessToken);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/OAuth2SuccessHandler.java
@@ -2,6 +2,8 @@ package com.kauniv.lightrip.global.oauth;
 
 import com.kauniv.lightrip.global.auth.entity.Auth;
 import com.kauniv.lightrip.global.auth.repository.AuthRepository;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
 import com.kauniv.lightrip.global.redis.service.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,7 +46,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String refreshToken = jwtProvider.generateRefreshToken(userId);
 
         Auth auth = authRepository.findByUser_IdAndSocialType(userId, socialType)
-                .orElseThrow(() -> new RuntimeException("Auth를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         redisService.saveRefreshToken(userId, refreshToken, jwtProvider.getRefreshTokenExpiration());
 

--- a/src/main/java/com/kauniv/lightrip/global/redis/service/RedisService.java
+++ b/src/main/java/com/kauniv/lightrip/global/redis/service/RedisService.java
@@ -2,6 +2,7 @@ package com.kauniv.lightrip.global.redis.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -30,7 +31,7 @@ public class RedisService {
             }
             return sb.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 해싱 실패", e);
+            throw new IllegalStateException("SHA-256 해싱 실패", e);
         }
     }
 
@@ -42,7 +43,7 @@ public class RedisService {
     public boolean isBlacklisted(String accessToken) {
         try {
             return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken));
-        } catch (Exception e) {
+        } catch (DataAccessException e) {
             log.warn("Redis 블랙리스트 조회 실패 — fail-open 처리 (token prefix={}...): {}",
                     accessToken.length() > 10 ? accessToken.substring(0, 10) : accessToken, e.getMessage());
             return false;

--- a/src/main/resources/static/dev/websocket-test.html
+++ b/src/main/resources/static/dev/websocket-test.html
@@ -22,24 +22,24 @@
 
 <div>
     <b>1. 토큰 발급</b><br>
-    userId: <input id="userId" value="1" style="width:80px">
+    <label for="userId">userId:</label> <input id="userId" value="1" style="width:80px">
     <button onclick="getToken()">토큰 발급</button>
     <span id="tokenDisplay"></span>
 </div>
 <br>
 <div>
     <b>2. WebSocket 연결</b><br>
-    teamId: <input id="teamId" value="1" style="width:80px">
+    <label for="teamId">teamId:</label> <input id="teamId" value="1" style="width:80px">
     <button onclick="connect()">연결</button>
     <button onclick="disconnect()">연결 끊기</button>
 </div>
 <br>
 <div>
     <b>3. 위치 전송</b><br>
-    nickname: <input id="nickname" value="테스트유저" style="width:120px">
-    latitude: <input id="lat" value="37.4979" style="width:100px">
-    longitude: <input id="lng" value="127.0276" style="width:100px">
-    placeName: <input id="place" value="강남역" style="width:100px">
+    <label for="nickname">nickname:</label> <input id="nickname" value="테스트유저" style="width:120px">
+    <label for="lat">latitude:</label> <input id="lat" value="37.4979" style="width:100px">
+    <label for="lng">longitude:</label> <input id="lng" value="127.0276" style="width:100px">
+    <label for="place">placeName:</label> <input id="place" value="강남역" style="width:100px">
     <button onclick="sendLocation()">위치 전송</button>
 </div>
 <br>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #163

## 📝 작업 내용
SonarCloud 정적 분석에서 제기된 Java 및 HTML 코드 품질 이슈 수정
**기존 파일 수정**
- `PaymentService.java` — `LocalDateTime.now()` → `ZonedDateTime.now(ZoneId.of("Asia/Seoul"))` (S6347)
- `RankingService.java` — `LocalDateTime.now()` → `LocalDateTime.now(ZoneId.of("Asia/Seoul"))` (S6347)
- `OAuth2SuccessHandler.java` — `new RuntimeException` → `BusinessException(ErrorCode.USER_NOT_FOUND)` (S112)
- `RedisService.java` — `RuntimeException` → `IllegalStateException`, `catch (Exception)` → `catch (DataAccessException)` (S112, S2221)
- `AiService.java` — `catch (Exception)` → `catch (RuntimeException)` (S2221)
- `AiClient.java` — `catch (Exception)` × 3 → `catch (RestClientException)` (S2221)
- `AuthController.java` — `substring(7)` 호출 전 `startsWith("Bearer ")` 검증 추가 (S2259)
- `websocket-test.html` — 6개 input 필드에 `<label for="...">` 연결 (Web:InputWithoutLabelCheck)

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

