### PR TITLE
feat: 여권 커버(대표사진) 팀 단위 지원

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/entity/DistrictCover.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/entity/DistrictCover.java
@@ -1,5 +1,6 @@
 package com.kauniv.lightrip.domain.passport.entity;
 
+import com.kauniv.lightrip.domain.team.entity.Team;
 import com.kauniv.lightrip.domain.user.entity.User;
 import com.kauniv.lightrip.global.enums.District;
 import jakarta.persistence.*;
@@ -14,15 +15,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(
-        name = "district_cover",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_district_cover_user_district",
-                        columnNames = {"user_id", "district_category"}
-                )
-        }
-)
+@Table(name = "district_cover")
+// > 유니크 제약은 개인/팀 부분 인덱스(uk_district_cover_user_district, uk_district_cover_team_district)로 DB에서 관리.
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -35,8 +29,14 @@ public class DistrictCover {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id")
     private User user;
+    // > 개인 커버의 작성자. 팀 커버이면 null (팀 단위로 관리).
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+    // > null이면 개인 커버, 값이 있으면 팀 커버.
 
     @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
     private String imageUrl;
@@ -66,5 +66,9 @@ public class DistrictCover {
 
     public void changeTextColor(String textColor) {
         this.textColor = textColor;
+    }
+
+    public boolean isTeamCover() {
+        return this.team != null;
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/DistrictCoverRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/DistrictCoverRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface DistrictCoverRepository extends JpaRepository<DistrictCover, Long> {
 
+    // 개인 커버 (team_id IS NULL): 팀 커버는 user_id가 null이므로 자동으로 제외됨
     Optional<DistrictCover> findByUser_IdAndDistrictCategory(Long userId, District districtCategory);
 
     boolean existsByUser_IdAndDistrictCategory(Long userId, District districtCategory);
@@ -15,4 +16,11 @@ public interface DistrictCoverRepository extends JpaRepository<DistrictCover, Lo
     void deleteByUser_IdAndDistrictCategory(Long userId, District districtCategory);
 
     List<DistrictCover> findAllByUser_Id(Long userId);
+
+    // 팀 커버 (team_id = teamId)
+    Optional<DistrictCover> findByTeam_IdAndDistrictCategory(Long teamId, District districtCategory);
+
+    boolean existsByTeam_IdAndDistrictCategory(Long teamId, District districtCategory);
+
+    List<DistrictCover> findAllByTeam_Id(Long teamId);
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -23,8 +23,14 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
 
     boolean existsByUser_IdAndDistrictCategory(Long userId, District districtCategory);
 
-    Optional<Passport> findFirstByUser_IdAndDistrictCategoryOrderByCreatedAtDesc(
+    // 개인 커버 재계산용: 팀 여권은 제외(team IS NULL)하고 본인 개인 여권 중 최신 1건
+    Optional<Passport> findFirstByUser_IdAndTeamIsNullAndDistrictCategoryOrderByCreatedAtDesc(
             Long userId, District districtCategory
+    );
+
+    // 팀 커버 재계산용: 해당 팀의 여권 중 최신 1건
+    Optional<Passport> findFirstByTeam_IdAndDistrictCategoryOrderByCreatedAtDesc(
+            Long teamId, District districtCategory
     );
 
     @Query("""

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/DistrictCoverService.java
@@ -4,6 +4,7 @@ import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverImageRequest
 import com.kauniv.lightrip.domain.passport.dto.request.DistrictCoverTextColorRequest;
 import com.kauniv.lightrip.domain.passport.entity.DistrictCover;
 import com.kauniv.lightrip.domain.passport.repository.DistrictCoverRepository;
+import com.kauniv.lightrip.domain.team.repository.TeamMemberRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,15 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class DistrictCoverService {
 
     private final DistrictCoverRepository districtCoverRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     @Transactional
     public void updateTextColor(Long userId, Long coverId, DistrictCoverTextColorRequest req) {
         DistrictCover cover = districtCoverRepository.findById(coverId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.DISTRICT_COVER_NOT_FOUND));
 
-        if (!cover.getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.DISTRICT_COVER_FORBIDDEN);
-        }
+        validatePermission(cover, userId);
 
         cover.changeTextColor(req.textColor());
     }
@@ -34,10 +34,21 @@ public class DistrictCoverService {
         DistrictCover cover = districtCoverRepository.findById(coverId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.DISTRICT_COVER_NOT_FOUND));
 
-        if (!cover.getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.DISTRICT_COVER_FORBIDDEN);
-        }
+        validatePermission(cover, userId);
 
         cover.changeCoverImage(req.imageUrl());
+    }
+
+    // > 팀 커버는 팀 멤버 누구나, 개인 커버는 작성자 본인만 변경 가능.
+    private void validatePermission(DistrictCover cover, Long userId) {
+        if (cover.isTeamCover()) {
+            if (!teamMemberRepository.existsByTeam_IdAndUser_Id(cover.getTeam().getId(), userId)) {
+                throw new BusinessException(ErrorCode.DISTRICT_COVER_FORBIDDEN);
+            }
+        } else {
+            if (!cover.getUser().getId().equals(userId)) {
+                throw new BusinessException(ErrorCode.DISTRICT_COVER_FORBIDDEN);
+            }
+        }
     }
 }

--- a/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/service/PassportService.java
@@ -121,8 +121,11 @@ public class PassportService {
         Passport passport = passportRepository.findById(passportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PASSPORT_NOT_FOUND));
         validateReadPermission(passport, userId);
-        Long coverId = districtCoverRepository
-                .findByUser_IdAndDistrictCategory(passport.getUser().getId(), passport.getDistrictCategory())
+        Long coverId = (passport.isTeamPassport()
+                ? districtCoverRepository.findByTeam_IdAndDistrictCategory(
+                        passport.getTeam().getId(), passport.getDistrictCategory())
+                : districtCoverRepository.findByUser_IdAndDistrictCategory(
+                        passport.getUser().getId(), passport.getDistrictCategory()))
                 .map(DistrictCover::getId)
                 .orElse(null);
         return PassportResponse.from(passport, coverId);
@@ -162,11 +165,16 @@ public class PassportService {
             throw new BusinessException(ErrorCode.PASSPORT_FORBIDDEN);
         }
         District district = passport.getDistrictCategory();
+        Team team = passport.getTeam();
         likeRepository.deleteAllByPassportId(passportId);
         scrapRepository.deleteAllByPassportId(passportId);
         passportRepository.delete(passport);
         passportRepository.flush();
-        cleanupDistrictCover(userId, district);
+        if (team != null) {
+            cleanupTeamDistrictCover(team.getId(), district);
+        } else {
+            cleanupDistrictCover(userId, district);
+        }
     }
 
     // ========== 외부 Service용 공개 메서드 ==========
@@ -178,24 +186,52 @@ public class PassportService {
     }
 
     // ========== DistrictCover 자동 생성 ==========
+    // > 팀 여권이면 팀 커버(user=null, team=값), 개인 여권이면 개인 커버(user=값, team=null) 생성.
     private void createDistrictCoverIfFirst(User user, Passport passport) {
         District district = passport.getDistrictCategory();
-        if (!districtCoverRepository.existsByUser_IdAndDistrictCategory(user.getId(), district)) {
-            String firstImageUrl = passport.getImages().get(0).getImageUrl();
-            DistrictCover cover = DistrictCover.builder()
-                    .user(user)
-                    .imageUrl(firstImageUrl)
-                    .districtCategory(district)
-                    .build();
-            districtCoverRepository.save(cover);
+        String firstImageUrl = passport.getImages().get(0).getImageUrl();
+
+        if (passport.isTeamPassport()) {
+            Team team = passport.getTeam();
+            if (!districtCoverRepository.existsByTeam_IdAndDistrictCategory(team.getId(), district)) {
+                districtCoverRepository.save(DistrictCover.builder()
+                        .team(team)
+                        .imageUrl(firstImageUrl)
+                        .districtCategory(district)
+                        .build());
+            }
+        } else {
+            if (!districtCoverRepository.existsByUser_IdAndDistrictCategory(user.getId(), district)) {
+                districtCoverRepository.save(DistrictCover.builder()
+                        .user(user)
+                        .imageUrl(firstImageUrl)
+                        .districtCategory(district)
+                        .build());
+            }
         }
     }
 
-    // ========== DistrictCover 정리 (삭제 시) ==========
+    // ========== DistrictCover 정리 (개인 여권 삭제 시) ==========
     private void cleanupDistrictCover(Long userId, District district) {
         districtCoverRepository.findByUser_IdAndDistrictCategory(userId, district)
                 .ifPresent(cover -> {
-                    passportRepository.findFirstByUser_IdAndDistrictCategoryOrderByCreatedAtDesc(userId, district)
+                    passportRepository.findFirstByUser_IdAndTeamIsNullAndDistrictCategoryOrderByCreatedAtDesc(userId, district)
+                            .ifPresentOrElse(
+                                    latestPassport -> {
+                                        if (!latestPassport.getImages().isEmpty()) {
+                                            cover.changeCoverImage(latestPassport.getImages().get(0).getImageUrl());
+                                        }
+                                    },
+                                    () -> districtCoverRepository.delete(cover)
+                            );
+                });
+    }
+
+    // ========== DistrictCover 정리 (팀 여권 삭제 시) ==========
+    private void cleanupTeamDistrictCover(Long teamId, District district) {
+        districtCoverRepository.findByTeam_IdAndDistrictCategory(teamId, district)
+                .ifPresent(cover -> {
+                    passportRepository.findFirstByTeam_IdAndDistrictCategoryOrderByCreatedAtDesc(teamId, district)
                             .ifPresentOrElse(
                                     latestPassport -> {
                                         if (!latestPassport.getImages().isEmpty()) {
@@ -248,11 +284,12 @@ public class PassportService {
     public List<DistrictResponse> getMyDistricts(Long userId, Long teamId) {
         if (teamId != null) validateTeamMembership(teamId, userId);
         List<Object[]> counts = passportRepository.countByUserIdGroupByDistrict(userId, teamId);
-        // 커버는 개인(user) 단위로만 존재 → 팀 모드에선 커버 정보 없음
-        Map<District, DistrictCover> coverMap = (teamId == null)
-                ? districtCoverRepository.findAllByUser_Id(userId).stream()
-                    .collect(Collectors.toMap(DistrictCover::getDistrictCategory, c -> c))
-                : Map.of();
+        // 개인 모드는 개인 커버, 팀 모드는 팀 커버를 지역별로 매핑
+        Map<District, DistrictCover> coverMap = ((teamId == null)
+                ? districtCoverRepository.findAllByUser_Id(userId)
+                : districtCoverRepository.findAllByTeam_Id(teamId))
+                .stream()
+                .collect(Collectors.toMap(DistrictCover::getDistrictCategory, c -> c));
         return counts.stream()
                 .map(row -> {
                     District district = (District) row[0];

--- a/src/main/resources/db/migration/V11__add_district_cover_team.sql
+++ b/src/main/resources/db/migration/V11__add_district_cover_team.sql
@@ -1,0 +1,20 @@
+-- district_cover에 팀 차원 추가: team_id가 NULL이면 개인 커버, 값이 있으면 팀 커버
+-- 팀 커버는 user_id = NULL, team_id = 값으로 저장 → 기존 user 기준 쿼리는 개인 커버만 조회됨
+ALTER TABLE public.district_cover ADD COLUMN team_id bigint;
+
+-- 팀 커버는 작성자(user_id)를 비우므로 NOT NULL 제거
+ALTER TABLE public.district_cover ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE public.district_cover
+    ADD CONSTRAINT fk_district_cover_team FOREIGN KEY (team_id) REFERENCES public.team(team_id);
+
+-- 기존 (user_id, district_category) 전체 유니크 제약을 제거하고, 개인/팀 부분 유니크 인덱스로 분리
+ALTER TABLE public.district_cover DROP CONSTRAINT uk_district_cover_user_district;
+
+CREATE UNIQUE INDEX uk_district_cover_user_district
+    ON public.district_cover (user_id, district_category)
+    WHERE team_id IS NULL;
+
+CREATE UNIQUE INDEX uk_district_cover_team_district
+    ON public.district_cover (team_id, district_category)
+    WHERE team_id IS NOT NULL;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #166 

## 📝 작업 내용

여권 커버(지역 대표사진, DistrictCover)를 팀 단위로도 관리할 수 있도록 확장했습니다.

설계

팀 커버는 user_id = NULL, team_id = 값으로 저장합니다.
이 방식 덕분에 기존 findByUser_Id... 쿼리들이 팀 커버를 자동으로 제외하여, FriendService 등 기존 코드는 수정이 필요 없습니다.
유니크 제약을 개인 (user_id, district) / 팀 (team_id, district) 부분 유니크 인덱스 2개로 분리했습니다.
주요 변경

V11 마이그레이션: team_id 컬럼 추가, user_id NOT NULL 해제, 부분 유니크 인덱스 분리
DistrictCover 엔티티: team 연관관계 추가, isTeamCover() 헬퍼
팀 여권 등록 시 팀 커버 자동 생성 / 삭제 시 자동 정리(cleanupTeamDistrictCover)
GET /passports/districts/me?teamId=X → 팀 커버 썸네일·coverId 반환 (기존엔 팀 모드에서 커버가 비어 있었음)
GET /passports/{id} → 팀 여권이면 팀 커버 coverId 반환
커버 변경 권한: 팀 커버는 팀 멤버 누구나, 개인 커버는 작성자 본인만
참고

불빛 지도(GET /lights/me?teamId=X)의 팀 여권 필터는 기존 findTeamLightClusters로 이미 구현되어 있어 동작 검증만 진행했습니다.
기존 개인 커버 데이터는 team_id = NULL로 유지되어 영향 없습니다.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

