### PR TITLE
CHORE: SonarCloud 중복 검사에서 DB 마이그레이션 제외

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+# SonarCloud 분석 설정
+# DB 마이그레이션(Flyway)은 한번 적용되면 수정할 수 없는 불변 파일이며,
+# DDL 특성상 반복 구문이 많아 중복(CPD) 검사 대상에서 제외한다.
+sonar.cpd.exclusions=**/db/migration/**


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

- SonarCloud Quality Gate 대응 (PR #173 후속)

## 📝 작업 내용

PR #173(여권 지역 enum 확장)에서 SonarCloud Quality Gate가 New Code 중복 9.6%(기준 ≤ 3%)로 실패했습니다.

원인은 `V12__split_gyeonggi_districts_into_gu.sql`에서 `passport` / `district_cover`용 CHECK 제약을 거의 동일한 블록 2개로 작성해 중복(43.2%)으로 잡힌 것입니다.

DB 마이그레이션은 한번 적용되면 수정할 수 없는 불변 파일(수정 시 Flyway 체크섬 불일치)이고 DDL 특성상 반복 구문이 많아, 중복(CPD) 검사 대상에서 제외합니다.

**변경**
- `sonar-project.properties` 추가 — `sonar.cpd.exclusions=**/db/migration/**`

> ⚠️ 현재 SonarCloud 자동분석(Automatic Analysis) 모드라 이 파일이 항상 적용되지 않을 수 있습니다. 확실히 하려면 SonarCloud UI의 Administration → Analysis Scope → Duplications → Duplication Exclusions에도 `**/db/migration/**`를 추가해주세요.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.