### PR TITLE
FIX: 회원탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
@@ -1,7 +1,6 @@
 package com.kauniv.lightrip.global.auth.service;
 
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
-import com.kauniv.lightrip.global.auth.repository.AuthRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
@@ -15,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AuthService {
 
-    private final AuthRepository authRepository;
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final RedisService redisService;
@@ -47,12 +45,11 @@ public class AuthService {
     }
 
     public void withdraw(Long userId, String accessToken) {
+        userRepository.deleteById(userId); // DB CASCADE가 auth 포함 연관 데이터 전부 삭제
         long expiration = jwtProvider.getExpiration(accessToken);
         if (expiration > 0) {
             redisService.addBlacklist(accessToken, expiration);
         }
         redisService.deleteRefreshToken(userId);
-        authRepository.deleteByUser_Id(userId);
-        userRepository.deleteById(userId);
     }
 }

--- a/src/main/resources/db/migration/V14__add_cascade_delete.sql
+++ b/src/main/resources/db/migration/V14__add_cascade_delete.sql
@@ -1,0 +1,104 @@
+-- 회원탈퇴 시 users 삭제가 FK 위반으로 실패하는 문제 수정 (Issue #177)
+-- users(user_id)를 참조하는 모든 FK와 passport(passport_id)를 참조하는 FK에 ON DELETE CASCADE 추가
+
+-- =============================================
+-- 1. users 참조 FK → ON DELETE CASCADE
+-- =============================================
+
+-- auth
+ALTER TABLE ONLY public.auth
+    DROP CONSTRAINT fkpv45mvdt7km1gvrtn5f9rsvd7;
+ALTER TABLE ONLY public.auth
+    ADD CONSTRAINT fkpv45mvdt7km1gvrtn5f9rsvd7 FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- ranking
+ALTER TABLE ONLY public.ranking
+    DROP CONSTRAINT fk3fvvh22u2cwktrkpu73la05yp;
+ALTER TABLE ONLY public.ranking
+    ADD CONSTRAINT fk3fvvh22u2cwktrkpu73la05yp FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- friend (요청자 / 수신자 모두)
+ALTER TABLE ONLY public.friend
+    DROP CONSTRAINT fk3t89853ilx0np8f323suufvty;
+ALTER TABLE ONLY public.friend
+    ADD CONSTRAINT fk3t89853ilx0np8f323suufvty FOREIGN KEY (request_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.friend
+    DROP CONSTRAINT fknbki3da2tox3pedxa9qs2gaqi;
+ALTER TABLE ONLY public.friend
+    ADD CONSTRAINT fknbki3da2tox3pedxa9qs2gaqi FOREIGN KEY (receiver_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- passport
+ALTER TABLE ONLY public.passport
+    DROP CONSTRAINT fkimp0xtvk5mujh4f1bkh7833vx;
+ALTER TABLE ONLY public.passport
+    ADD CONSTRAINT fkimp0xtvk5mujh4f1bkh7833vx FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- likes
+ALTER TABLE ONLY public.likes
+    DROP CONSTRAINT fknvx9seeqqyy71bij291pwiwrg;
+ALTER TABLE ONLY public.likes
+    ADD CONSTRAINT fknvx9seeqqyy71bij291pwiwrg FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- scrap
+ALTER TABLE ONLY public.scrap
+    DROP CONSTRAINT fk6jcivlvmiwrx9hd1d7h2tkije;
+ALTER TABLE ONLY public.scrap
+    ADD CONSTRAINT fk6jcivlvmiwrx9hd1d7h2tkije FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- district_cover
+ALTER TABLE ONLY public.district_cover
+    DROP CONSTRAINT fk9gi6fa8gt7hxcvl08ta7pr4ll;
+ALTER TABLE ONLY public.district_cover
+    ADD CONSTRAINT fk9gi6fa8gt7hxcvl08ta7pr4ll FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- team_member
+ALTER TABLE ONLY public.team_member
+    DROP CONSTRAINT fkcwlc6ivvbf5svve5fmbg71vks;
+ALTER TABLE ONLY public.team_member
+    ADD CONSTRAINT fkcwlc6ivvbf5svve5fmbg71vks FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- payment
+ALTER TABLE ONLY public.payment
+    DROP CONSTRAINT fk_payment_user;
+ALTER TABLE ONLY public.payment
+    ADD CONSTRAINT fk_payment_user FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON DELETE CASCADE;
+
+-- =============================================
+-- 2. passport 참조 FK → ON DELETE CASCADE
+--    (탈퇴 유저 여권 삭제 시 다른 유저의 likes/scrap도 연쇄 삭제)
+-- =============================================
+
+-- passport_image
+ALTER TABLE ONLY public.passport_image
+    DROP CONSTRAINT fk2v26bdu2o9b5i8mv3ef8ldyv1;
+ALTER TABLE ONLY public.passport_image
+    ADD CONSTRAINT fk2v26bdu2o9b5i8mv3ef8ldyv1 FOREIGN KEY (passport_id) REFERENCES public.passport(passport_id) ON DELETE CASCADE;
+
+-- passport_stamp
+ALTER TABLE ONLY public.passport_stamp
+    DROP CONSTRAINT fks68ubk271qdme3btnhlsf09mo;
+ALTER TABLE ONLY public.passport_stamp
+    ADD CONSTRAINT fks68ubk271qdme3btnhlsf09mo FOREIGN KEY (passport_id) REFERENCES public.passport(passport_id) ON DELETE CASCADE;
+
+-- likes (다른 유저가 이 여권에 누른 좋아요)
+ALTER TABLE ONLY public.likes
+    DROP CONSTRAINT fkltqvd5mqg4c0dhmt241qnfuny;
+ALTER TABLE ONLY public.likes
+    ADD CONSTRAINT fkltqvd5mqg4c0dhmt241qnfuny FOREIGN KEY (passport_id) REFERENCES public.passport(passport_id) ON DELETE CASCADE;
+
+-- scrap (다른 유저가 이 여권을 스크랩)
+ALTER TABLE ONLY public.scrap
+    DROP CONSTRAINT fklsmigjultu7jx5u3f8diygwv3;
+ALTER TABLE ONLY public.scrap
+    ADD CONSTRAINT fklsmigjultu7jx5u3f8diygwv3 FOREIGN KEY (passport_id) REFERENCES public.passport(passport_id) ON DELETE CASCADE;
+
+-- =============================================
+-- 3. passport_image 참조 FK → ON DELETE CASCADE
+--    (passport_image 삭제 시 district_cover 연쇄 삭제)
+-- =============================================
+
+ALTER TABLE ONLY public.district_cover
+    DROP CONSTRAINT fk5tnx93oul5yn1a2omidbwfcl6;
+ALTER TABLE ONLY public.district_cover
+    ADD CONSTRAINT fk5tnx93oul5yn1a2omidbwfcl6 FOREIGN KEY (passport_image_id) REFERENCES public.passport_image(passport_image_id) ON DELETE CASCADE;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

Closes #177

## 📝 작업 내용

데이터가 있는 유저가 회원탈퇴 시 FK 제약 위반으로 500 에러가 발생하는 문제를 수정
또한 기존 로직은 DB 실패 시에도 Redis 토큰이 먼저 삭제돼 로그인 불가 상태가 되는 부작용이 있었음

**변경 사항**

신규 생성
- `V14__add_cascade_delete.sql` — `users`, `passport`, `passport_image` 참조 FK 전체에 `ON DELETE CASCADE` 추가

기존 파일 수정
- `AuthService.java` — DB 삭제 선행 / Redis 처리 후행으로 순서 변경, 중복된 `authRepository.deleteByUser_Id()` 제거

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

