### PR TITLE
FIX: 팀 리더 탈퇴 시 팀 여권 삭제 및 district_cover FK cascade 추가

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/passport/repository/PassportRepository.java
@@ -271,6 +271,10 @@ public interface PassportRepository extends JpaRepository<Passport, Long> {
     @Query("UPDATE Passport p SET p.team = null WHERE p.team.id = :teamId")
     void clearTeamReference(@Param("teamId") Long teamId);
 
+    @Modifying
+    @Query("DELETE FROM Passport p WHERE p.team.id = :teamId")
+    void deleteAllByTeamId(@Param("teamId") Long teamId);
+
     @Query("""
     SELECT p.user.id, COUNT(p)
     FROM Passport p

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -120,8 +120,10 @@ public class TeamService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_MEMBER));
 
         if (member.getRole() == TeamMember.Role.LEADER) {
-            // > LEADER 탈퇴 = 팀 해산. passport.team_id FK 제약 때문에 먼저 null 처리 후 삭제.
-            passportRepository.clearTeamReference(teamId);
+            // > LEADER 탈퇴 = 팀 해산.
+            // > 팀 여권 먼저 삭제 (passport.team_id FK 제약 해제 + 팀 여권 제거).
+            // > district_cover 팀 커버는 team.team_id ON DELETE CASCADE (V15)로 연쇄 삭제.
+            passportRepository.deleteAllByTeamId(teamId);
             teamMemberRepository.deleteAllByTeam_Id(teamId);
             teamRepository.delete(member.getTeam());
             return;

--- a/src/main/resources/db/migration/V15__add_team_cascade_delete.sql
+++ b/src/main/resources/db/migration/V15__add_team_cascade_delete.sql
@@ -1,0 +1,7 @@
+-- 팀 해산 시 district_cover 팀 커버 FK 위반 수정 (Issue #177 관련)
+-- district_cover.team_id → team.team_id: ON DELETE CASCADE 추가
+
+ALTER TABLE ONLY public.district_cover
+    DROP CONSTRAINT fk_district_cover_team;
+ALTER TABLE ONLY public.district_cover
+    ADD CONSTRAINT fk_district_cover_team FOREIGN KEY (team_id) REFERENCES public.team(team_id) ON DELETE CASCADE;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #179 

## 📝 작업 내용
팀 리더 탈퇴(팀 해산) 시 팀 여권이 삭제되지 않고 개인 여권으로 전환되는 버그,
그리고 district_cover 팀 커버 FK cascade 누락으로 인한 500 에러를 수정합니다.

**변경 사항**
신규 생성
- `V15__add_team_cascade_delete.sql` — district_cover.team_id → team.team_id ON DELETE CASCADE 추가

기존 파일 수정
- `PassportRepository.java` — deleteAllByTeamId 메서드 추가 (팀 여권 일괄 삭제)
- `TeamService.java` — leave() 리더 탈퇴 로직에서 clearTeamReference → deleteAllByTeamId 교체

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.