### PR TITLE
FIX: V14 마이그레이션 district_cover 존재하지 않는 FK 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
               --name lightrip-prod \
               --restart always \
               -p 8080:8080 \
+              --network lightrip-net \
               --env-file /home/ec2-user/.env \
               $ECR_REGISTRY/lightrip-server:main
         env:
@@ -84,6 +85,7 @@ jobs:
               --name lightrip-dev \
               --restart always \
               -p 8081:8080 \
+              --network lightrip-net \
               --env-file /home/ec2-user/.env.dev \
               $ECR_REGISTRY/lightrip-server:develop
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.db
+    container_name: lightrip-db
     environment:
       POSTGRES_DB: lightrip
       POSTGRES_USER: ${DB_USERNAME}
@@ -12,14 +13,25 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init:/docker-entrypoint-initdb.d
+    networks:
+      - lightrip-net
+    restart: always
 
   redis:
     image: redis:7-alpine
+    container_name: lightrip-redis
     ports:
       - "6379:6379"
     volumes:
       - redis_data:/data
+    networks:
+      - lightrip-net
+    restart: always
 
 volumes:
   postgres_data:
   redis_data:
+
+networks:
+  lightrip-net:
+    name: lightrip-net

--- a/src/main/resources/db/migration/V14__add_cascade_delete.sql
+++ b/src/main/resources/db/migration/V14__add_cascade_delete.sql
@@ -93,12 +93,3 @@ ALTER TABLE ONLY public.scrap
 ALTER TABLE ONLY public.scrap
     ADD CONSTRAINT fklsmigjultu7jx5u3f8diygwv3 FOREIGN KEY (passport_id) REFERENCES public.passport(passport_id) ON DELETE CASCADE;
 
--- =============================================
--- 3. passport_image 참조 FK → ON DELETE CASCADE
---    (passport_image 삭제 시 district_cover 연쇄 삭제)
--- =============================================
-
-ALTER TABLE ONLY public.district_cover
-    DROP CONSTRAINT fk5tnx93oul5yn1a2omidbwfcl6;
-ALTER TABLE ONLY public.district_cover
-    ADD CONSTRAINT fk5tnx93oul5yn1a2omidbwfcl6 FOREIGN KEY (passport_image_id) REFERENCES public.passport_image(passport_image_id) ON DELETE CASCADE;


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
없음 (마이그레이션 버그 핫픽스)

## 📝 작업 내용
V14__add_cascade_delete.sql에서 district_cover 테이블의 passport_image_id FK cascade 섹션 제거

district_cover 테이블에 passport_image_id 컬럼이 존재하지 않아 dev 환경에서 Flyway V14 마이그레이션 실패하는 버그 수정

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.