### PR TITLE
fix: 토큰 재발급 시 회전된 refreshToken 을 응답에 포함

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
@@ -23,12 +23,7 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
             @RequestHeader("Refresh-Token") String refreshToken) {
-        String newAccessToken = authService.reissueAccessToken(refreshToken);
-        return ResponseEntity.ok(
-                TokenResponse.builder()
-                        .accessToken(newAccessToken)
-                        .build()
-        );
+        return ResponseEntity.ok(authService.reissueAccessToken(refreshToken));
     }
 
     @Operation(summary = "로그아웃", description = "액세스 토큰을 블랙리스트에 등록하고 리프레시 토큰을 삭제합니다.")

--- a/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.kauniv.lightrip.global.auth.service;
 
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
+import com.kauniv.lightrip.global.auth.dto.TokenResponse;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
@@ -18,7 +19,9 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RedisService redisService;
 
-    public String reissueAccessToken(String refreshToken) {
+    // > refreshToken을 회전시키므로 새 refreshToken도 함께 반환해야 한다.
+    // > 반환하지 않으면 클라이언트가 이전 토큰을 계속 들고 있어 다음 재발급이 REFRESH_TOKEN_MISMATCH로 실패한다.
+    public TokenResponse reissueAccessToken(String refreshToken) {
         if (!jwtProvider.validateToken(refreshToken)) {
             throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
@@ -33,7 +36,10 @@ public class AuthService {
         String newRefreshToken = jwtProvider.generateRefreshToken(userId);
         redisService.saveRefreshToken(userId, newRefreshToken, jwtProvider.getRefreshTokenExpiration());
 
-        return newAccessToken;
+        return TokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
     }
 
     public void logout(Long userId, String accessToken) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> QA — 시간이 지나면 로그아웃되는 문제

## 📝 작업 내용

> **⚠️ 프론트 PR과 함께 배포 필요** (LighTrip-Front-end#152)

`reissueAccessToken` 이 refreshToken 을 새로 발급해 Redis 에 덮어쓰면서, 응답에는 accessToken 만 담아 보내고 있었습니다.

클라이언트는 이전 refreshToken 을 계속 들고 있게 되어 Redis 의 값과 어긋나고, **두 번째 재발급부터 `REFRESH_TOKEN_MISMATCH` 로 실패**합니다. 결과적으로 재발급이 한 번만 동작합니다.

- `reissueAccessToken` 반환 타입을 `TokenResponse` 로 변경하고 새 refreshToken 을 함께 반환
- `AuthController` 는 서비스가 만든 응답을 그대로 전달

`TokenResponse` 는 `@JsonInclude(NON_NULL)` 이라 기존 응답 형태와 호환됩니다.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다. (compileJava 통과)
