### PR TITLE
FEAT: Apple 로그인(Sign in with Apple) 연동

### DIFF
--- a/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/controller/AuthController.java
@@ -1,11 +1,15 @@
 package com.kauniv.lightrip.global.auth.controller;
 
+import com.kauniv.lightrip.global.auth.dto.AppleLoginRequest;
+import com.kauniv.lightrip.global.auth.dto.LoginResponse;
 import com.kauniv.lightrip.global.auth.dto.TokenResponse;
+import com.kauniv.lightrip.global.auth.service.AppleAuthService;
 import com.kauniv.lightrip.global.auth.service.AuthService;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +22,13 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final AppleAuthService appleAuthService;
+
+    @Operation(summary = "Apple 로그인", description = "iOS 네이티브 Sign in with Apple로 받은 identityToken을 검증하고 자체 JWT를 발급합니다.")
+    @PostMapping("/apple/login")
+    public ResponseEntity<LoginResponse> appleLogin(@Valid @RequestBody AppleLoginRequest request) {
+        return ResponseEntity.ok(appleAuthService.login(request));
+    }
 
     @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰으로 새 액세스 토큰을 발급받습니다.")
     @PostMapping("/refresh")

--- a/src/main/java/com/kauniv/lightrip/global/auth/dto/AppleLoginRequest.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/dto/AppleLoginRequest.java
@@ -1,0 +1,21 @@
+package com.kauniv.lightrip.global.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// > identityToken: iOS 네이티브 SDK가 발급한 JWT, 서버에서 Apple JWKS로 서명 검증
+// > nickname: Apple이 최초 로그인 1회에만 클라이언트로 내려주는 fullName. 재로그인 시엔 없으므로 nullable.
+// > authorizationCode: 매 로그인 시도마다 발급되는 1회용 코드. 최초 가입 시점에 Apple refresh_token으로
+// > 교환해 저장해두고, 탈퇴 시 연동 해제(revoke)에 사용함. nullable — 없으면 교환/저장을 건너뜀.
+@Getter
+@NoArgsConstructor
+public class AppleLoginRequest {
+
+    @NotBlank
+    private String identityToken;
+
+    private String nickname;
+
+    private String authorizationCode;
+}

--- a/src/main/java/com/kauniv/lightrip/global/auth/dto/LoginResponse.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/dto/LoginResponse.java
@@ -9,4 +9,5 @@ public class LoginResponse {
 
     private String accessToken;
     private String refreshToken;
+    private boolean isNewUser;
 }

--- a/src/main/java/com/kauniv/lightrip/global/auth/service/AppleAuthService.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/service/AppleAuthService.java
@@ -1,0 +1,86 @@
+package com.kauniv.lightrip.global.auth.service;
+
+import com.kauniv.lightrip.domain.user.service.UserService;
+import com.kauniv.lightrip.global.auth.dto.AppleLoginRequest;
+import com.kauniv.lightrip.global.auth.dto.LoginResponse;
+import com.kauniv.lightrip.global.auth.entity.Auth;
+import com.kauniv.lightrip.global.common.exception.BusinessException;
+import com.kauniv.lightrip.global.common.exception.ErrorCode;
+import com.kauniv.lightrip.global.jwt.JwtProvider;
+import com.kauniv.lightrip.global.oauth.SocialType;
+import com.kauniv.lightrip.global.oauth.apple.AppleTokenClient;
+import com.kauniv.lightrip.global.oauth.userinfo.AppleOAuth2UserInfo;
+import com.kauniv.lightrip.global.redis.service.RedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// > 카카오는 Spring Security oauth2Login(인가코드 리다이렉트) 흐름을 타지만,
+// > Apple은 RN 네이티브 SDK가 이미 발급받은 identityToken을 REST로 그대로 넘겨주는 구조라
+// > CustomOAuth2UserService/OAuth2SuccessHandler 대신 이 서비스가 검증부터 토큰 발급까지 전담함.
+// > 이후 User/Auth 생성 로직(findOrCreateUser)은 카카오와 동일한 UserService를 그대로 재사용.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AppleAuthService {
+
+    private final JwtDecoder appleJwtDecoder;
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+    private final AppleTokenClient appleTokenClient;
+
+    public LoginResponse login(AppleLoginRequest request) {
+        Jwt jwt;
+        try {
+            jwt = appleJwtDecoder.decode(request.getIdentityToken());
+        } catch (JwtException e) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String providerId = jwt.getSubject();
+        String email = jwt.getClaimAsString("email");
+
+        boolean isNewUser = !userService.existsBySocialInfo(providerId, SocialType.APPLE);
+
+        AppleOAuth2UserInfo userInfo = new AppleOAuth2UserInfo(providerId, email, request.getNickname());
+        Auth auth = userService.findOrCreateUser(userInfo, SocialType.APPLE);
+
+        if (isNewUser) {
+            storeAppleRefreshToken(auth, request.getAuthorizationCode());
+        }
+
+        Long userId = auth.getUser().getId();
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String refreshToken = jwtProvider.generateRefreshToken(userId);
+        redisService.saveRefreshToken(userId, refreshToken, jwtProvider.getRefreshTokenExpiration());
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isNewUser(isNewUser)
+                .build();
+    }
+
+    // > 탈퇴 시 필요한 revoke용 refresh_token을 미리 확보해두는 과정.
+    // > 실패해도 로그인 자체는 계속 진행 — 이 단계는 나중 탈퇴 흐름을 위한 부가 작업이라 로그인을 막을 이유가 없음.
+    private void storeAppleRefreshToken(Auth auth, String authorizationCode) {
+        if (authorizationCode == null || authorizationCode.isBlank()) {
+            log.warn("Apple authorizationCode가 없어 refreshToken 저장을 건너뜁니다. userId={}", auth.getUser().getId());
+            return;
+        }
+        try {
+            String appleRefreshToken = appleTokenClient.exchangeAuthorizationCode(authorizationCode);
+            if (appleRefreshToken != null) {
+                auth.updateRefreshToken(appleRefreshToken);
+            }
+        } catch (Exception e) {
+            log.warn("Apple authorizationCode 교환 실패, userId={}", auth.getUser().getId(), e);
+        }
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
@@ -2,14 +2,20 @@ package com.kauniv.lightrip.global.auth.service;
 
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.auth.dto.TokenResponse;
+import com.kauniv.lightrip.global.auth.entity.Auth;
+import com.kauniv.lightrip.global.auth.repository.AuthRepository;
 import com.kauniv.lightrip.global.common.exception.BusinessException;
 import com.kauniv.lightrip.global.common.exception.ErrorCode;
 import com.kauniv.lightrip.global.jwt.JwtProvider;
+import com.kauniv.lightrip.global.oauth.SocialType;
+import com.kauniv.lightrip.global.oauth.apple.AppleTokenClient;
 import com.kauniv.lightrip.global.redis.service.RedisService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -18,6 +24,8 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final RedisService redisService;
+    private final AuthRepository authRepository;
+    private final AppleTokenClient appleTokenClient;
 
     // > refreshToken을 회전시키므로 새 refreshToken도 함께 반환해야 한다.
     // > 반환하지 않으면 클라이언트가 이전 토큰을 계속 들고 있어 다음 재발급이 REFRESH_TOKEN_MISMATCH로 실패한다.
@@ -51,11 +59,27 @@ public class AuthService {
     }
 
     public void withdraw(Long userId, String accessToken) {
+        revokeAppleIfLinked(userId); // CASCADE로 Auth가 같이 삭제되기 전에 revoke용 refreshToken을 먼저 사용
         userRepository.deleteById(userId); // DB CASCADE가 auth 포함 연관 데이터 전부 삭제
         long expiration = jwtProvider.getExpiration(accessToken);
         if (expiration > 0) {
             redisService.addBlacklist(accessToken, expiration);
         }
         redisService.deleteRefreshToken(userId);
+    }
+
+    // > Apple 계정으로 가입한 유저가 탈퇴하면 Apple 쪽 연동도 끊어줘야 함 (App Store 심사 가이드라인 5.1.1(v)).
+    // > revoke 실패해도 탈퇴 자체는 막지 않음 — Apple API 장애로 유저가 탈퇴를 못 하게 되는 게 더 나쁨.
+    private void revokeAppleIfLinked(Long userId) {
+        authRepository.findByUser_IdAndSocialType(userId, SocialType.APPLE)
+                .map(Auth::getRefreshToken)
+                .filter(token -> token != null && !token.isBlank())
+                .ifPresent(token -> {
+                    try {
+                        appleTokenClient.revoke(token);
+                    } catch (Exception e) {
+                        log.warn("Apple 계정 연동 해제 실패, userId={}", userId, e);
+                    }
+                });
     }
 }

--- a/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/", "/oauth2/**", "/login/**", "/auth/refresh",
+                                "/", "/oauth2/**", "/login/**", "/auth/refresh", "/auth/apple/login",
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
                                 "/actuator/**", "/ws/**",
                                 "/dev/**"   // dev 프로파일 전용 — @Profile("dev") 로 prod에서는 Bean 비활성화

--- a/src/main/java/com/kauniv/lightrip/global/oauth/SocialType.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/SocialType.java
@@ -2,5 +2,6 @@ package com.kauniv.lightrip.global.oauth;
 
 public enum SocialType {
     KAKAO,
-    GOOGLE
+    GOOGLE,
+    APPLE
 }

--- a/src/main/java/com/kauniv/lightrip/global/oauth/apple/AppleClientSecretGenerator.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/apple/AppleClientSecretGenerator.java
@@ -1,0 +1,69 @@
+package com.kauniv.lightrip.global.oauth.apple;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+
+// > Apple 토큰 교환(/auth/token)·해제(/auth/revoke) API를 호출할 때 우리 서버 신원을 증명하는
+// > client_secret(ES256 서명 JWT)을 그때그때 생성함. 로그인 검증(identityToken)과는 반대 방향 —
+// > 여기선 우리가 Apple Developer에서 받은 개인키(.p8)로 직접 서명함.
+// > 호출마다 새로 만들고 만료를 짧게(5분) 잡음. 캐싱해서 재사용해도 되지만(Apple 최대 6개월 허용),
+// > 호출 빈도가 낮아(회원가입/탈퇴 시점뿐) 캐싱 이점이 크지 않아 단순하게 매번 생성.
+@Component
+public class AppleClientSecretGenerator {
+
+    private static final String APPLE_AUDIENCE = "https://appleid.apple.com";
+
+    @Value("${apple.team-id}")
+    private String teamId;
+
+    @Value("${apple.key-id}")
+    private String keyId;
+
+    @Value("${apple.bundle-id}")
+    private String bundleId;
+
+    @Value("${apple.private-key}")
+    private String privateKeyValue;
+
+    public String generate() {
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .header().add("kid", keyId).and()
+                .issuer(teamId)
+                .subject(bundleId)
+                .audience().add(APPLE_AUDIENCE).and()
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(5, ChronoUnit.MINUTES)))
+                .signWith(loadPrivateKey(), Jwts.SIG.ES256)
+                .compact();
+    }
+
+    // > .env엔 개행이 없는 한 줄로 저장하는 게 편해서(예: "-----BEGIN PRIVATE KEY-----\nMII...\n-----END..."),
+    // > 헤더/푸터 문자열과 실제 개행, 이스케이프된 "\n" 리터럴을 전부 제거하고 순수 base64만 남겨서 디코딩.
+    private PrivateKey loadPrivateKey() {
+        String base64 = privateKeyValue
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replace("\\n", "")
+                .replaceAll("\\s", "");
+
+        try {
+            byte[] decoded = Base64.getDecoder().decode(base64);
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decoded);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(spec);
+        } catch (Exception e) {
+            throw new IllegalStateException("apple.private-key 파싱 실패 — .p8 키 형식을 확인하세요.", e);
+        }
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/apple/AppleJwtConfig.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/apple/AppleJwtConfig.java
@@ -1,0 +1,43 @@
+package com.kauniv.lightrip.global.oauth.apple;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+// > RN 앱이 iOS 네이티브 Sign in with Apple SDK로 직접 받아온 identityToken을 백엔드로 넘기는 구조라
+// > Spring Security의 oauth2Login(인가코드 리다이렉트 흐름)을 안 타고, 이 JwtDecoder로 토큰만 검증함.
+// > NimbusJwtDecoder가 Apple의 공개키(JWKS)를 가져와 캐싱하고 kid로 매칭해 서명을 검증함 — 별도 라이브러리 추가 불필요
+// > (spring-boot-starter-security-oauth2-resource-server에 이미 포함된 nimbus-jose-jwt 사용).
+@Configuration
+public class AppleJwtConfig {
+
+    private static final String APPLE_JWK_SET_URI = "https://appleid.apple.com/auth/keys";
+    private static final String APPLE_ISSUER = "https://appleid.apple.com";
+
+    @Value("${apple.bundle-id}")
+    private String appleBundleId;
+
+    @Bean
+    public JwtDecoder appleJwtDecoder() {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(APPLE_JWK_SET_URI).build();
+
+        // > iss(발급자)+exp/nbf 기본 검증 + aud(Bundle ID) 커스텀 검증을 합쳐서 하나의 validator로 구성
+        OAuth2TokenValidator<Jwt> defaultValidator = JwtValidators.createDefaultWithIssuer(APPLE_ISSUER);
+        OAuth2TokenValidator<Jwt> audienceValidator = jwt ->
+                jwt.getAudience().contains(appleBundleId)
+                        ? OAuth2TokenValidatorResult.success()
+                        : OAuth2TokenValidatorResult.failure(
+                        new OAuth2Error("invalid_token", "Apple identityToken의 aud가 Bundle ID와 일치하지 않습니다.", null));
+
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(defaultValidator, audienceValidator));
+        return decoder;
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/apple/AppleTokenClient.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/apple/AppleTokenClient.java
@@ -1,0 +1,62 @@
+package com.kauniv.lightrip.global.oauth.apple;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+// > Apple의 OAuth 토큰 엔드포인트(/auth/token, /auth/revoke) 호출 전담.
+// > RestClientConfig의 Bean은 자체 AI 서버(ai.lightrip.cloud) 전용이라 재사용하지 않고 별도 RestClient 사용.
+@Component
+@RequiredArgsConstructor
+public class AppleTokenClient {
+
+    private static final String APPLE_TOKEN_URI = "https://appleid.apple.com/auth/token";
+    private static final String APPLE_REVOKE_URI = "https://appleid.apple.com/auth/revoke";
+
+    private final AppleClientSecretGenerator clientSecretGenerator;
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${apple.bundle-id}")
+    private String bundleId;
+
+    // > 최초 로그인 시 RN이 넘겨준 authorizationCode를 Apple의 refresh_token으로 교환.
+    // > 이 refresh_token을 Auth.refreshToken에 저장해뒀다가 탈퇴 시 revoke()에 사용함.
+    public String exchangeAuthorizationCode(String authorizationCode) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("client_id", bundleId);
+        form.add("client_secret", clientSecretGenerator.generate());
+        form.add("code", authorizationCode);
+        form.add("grant_type", "authorization_code");
+
+        Map<String, Object> response = restClient.post()
+                .uri(APPLE_TOKEN_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(form)
+                .retrieve()
+                .body(Map.class);
+
+        return response != null ? (String) response.get("refresh_token") : null;
+    }
+
+    // > 회원탈퇴 시 저장해둔 refresh_token으로 Apple 쪽 연동을 해제 (App Store 심사 가이드라인 5.1.1(v)).
+    public void revoke(String appleRefreshToken) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("client_id", bundleId);
+        form.add("client_secret", clientSecretGenerator.generate());
+        form.add("token", appleRefreshToken);
+        form.add("token_type_hint", "refresh_token");
+
+        restClient.post()
+                .uri(APPLE_REVOKE_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(form)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/src/main/java/com/kauniv/lightrip/global/oauth/userinfo/AppleOAuth2UserInfo.java
+++ b/src/main/java/com/kauniv/lightrip/global/oauth/userinfo/AppleOAuth2UserInfo.java
@@ -1,0 +1,38 @@
+package com.kauniv.lightrip.global.oauth.userinfo;
+
+import java.util.UUID;
+
+// > Apple identity token(JWT)에는 nickname이 없음 — Apple은 최초 로그인 1회에 한해 fullName을
+// > 클라이언트(RN)에만 전달하고, 백엔드로는 넘어오지 않음. 클라이언트가 그 값을 nickname으로
+// > 함께 보내주면 사용하고, 없으면 임시 닉네임을 생성해서 User.nickname(NOT NULL, UNIQUE) 제약을 만족시킴.
+// > 카카오와 동일하게 신규 유저는 온보딩(PATCH /api/v1/users/me/onboarding)에서 실제 닉네임을 다시 설정하므로
+// > 여기서 만든 임시값은 그때까지의 자리표시자 역할만 함.
+public class AppleOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final String providerId;
+    private final String email;
+    private final String nickname;
+
+    public AppleOAuth2UserInfo(String providerId, String email, String nickname) {
+        this.providerId = providerId;
+        this.email = email;
+        this.nickname = (nickname != null && !nickname.isBlank())
+                ? nickname
+                : "user_" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    @Override
+    public String getProviderId() {
+        return providerId;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,12 @@ spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/o
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 
+# Apple Sign In
+apple.bundle-id=${APPLE_BUNDLE_ID}
+apple.team-id=${APPLE_TEAM_ID}
+apple.key-id=${APPLE_KEY_ID}
+apple.private-key=${APPLE_PRIVATE_KEY}
+
 # JWT
 jwt.secret=${JWT_SECRET}
 jwt.access-token-expiration=10800000


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #187 

## 📝 작업 내용
Apple 로그인(Sign in with Apple) 백엔드 지원 + 탈퇴 시 Apple 계정 연동 해제 구현.

**변경 사항**
신규 생성
- AppleLoginRequest — identityToken/nickname/authorizationCode 요청 DTO
- AppleAuthService — identityToken 검증, 로그인/가입 처리, JWT 발급
- AppleJwtConfig — Apple JWKS 기반 identityToken 검증 Bean
- AppleClientSecretGenerator — Team ID/Key ID/.p8로 client_secret(ES256 JWT) 생성
- AppleTokenClient — Apple /auth/token(코드 교환), /auth/revoke(연동 해제) 호출
- AppleOAuth2UserInfo — Apple 프로필 매핑 (nickname 없으면 임시값 생성)

기존 파일 수정
- AuthController — POST /auth/apple/login 추가
- AuthService — withdraw 시 Apple 연동 해제(revoke) 로직 추가
- LoginResponse — isNewUser 필드 추가
- SecurityConfig — /auth/apple/login permitAll 추가
- SocialType — APPLE 추가
- application.properties — apple.bundle-id/team-id/key-id/private-key 추가

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다. (실기기 identityToken 필요 — RN 연동 전까지 미검증, client_secret 서명은 검증 완료)