### PR TITLE
FIX: 팀 생성/탈퇴 데이터 정합성 버그 수정

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/repository/TeamMemberRepository.java
@@ -22,6 +22,11 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     // 유저가 속한 팀 조회 (유저당 팀 1개)
     Optional<TeamMember> findByUser_Id(Long userId);
 
+    boolean existsByUser_Id(Long userId);
+
+    // 탈퇴 시 소속된 모든 팀 정리용 (유저당 팀 1개가 정상이지만, 과거 데이터 정합성 깨짐에 대비해 List로 조회)
+    List<TeamMember> findAllByUser_Id(Long userId);
+
     @Modifying
     @Query("DELETE FROM TeamMember tm WHERE tm.team.id = :teamId")
     void deleteAllByTeam_Id(@Param("teamId") Long teamId);

--- a/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/team/service/TeamService.java
@@ -45,6 +45,10 @@ public class TeamService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        if (teamMemberRepository.existsByUser_Id(userId)) {
+            throw new BusinessException(ErrorCode.TEAM_ALREADY_JOINED);
+        }
+
         String teamCode = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
 
         Team team = Team.builder()
@@ -77,7 +81,7 @@ public class TeamService {
         Team team = teamRepository.findByTeamCode(req.teamCode())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_INVALID_CODE));
 
-        if (teamMemberRepository.existsByTeam_IdAndUser_Id(team.getId(), userId)) {
+        if (teamMemberRepository.existsByUser_Id(userId)) {
             throw new BusinessException(ErrorCode.TEAM_ALREADY_JOINED);
         }
 
@@ -120,16 +124,36 @@ public class TeamService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_MEMBER));
 
         if (member.getRole() == TeamMember.Role.LEADER) {
-            // > LEADER 탈퇴 = 팀 해산.
-            // > 팀 여권 먼저 삭제 (passport.team_id FK 제약 해제 + 팀 여권 제거).
-            // > district_cover 팀 커버는 team.team_id ON DELETE CASCADE (V15)로 연쇄 삭제.
-            passportRepository.deleteAllByTeamId(teamId);
-            teamMemberRepository.deleteAllByTeam_Id(teamId);
-            teamRepository.delete(member.getTeam());
+            disbandTeam(member);
             return;
         }
 
         teamMemberRepository.delete(member);
+    }
+
+    // > 회원 탈퇴 시 호출. AuthService.withdraw()가 유저 삭제 전에 호출해
+    // > 리더가 탈퇴하면 팀을 해산하고, 팀원이면 팀에서만 제거한다.
+    // > DB CASCADE(V14)는 team_member 행만 지우고 team 자체는 정리하지 않으므로 반드시 필요.
+    @Transactional
+    public void leaveAllTeams(Long userId) {
+        List<TeamMember> memberships = teamMemberRepository.findAllByUser_Id(userId);
+        for (TeamMember member : memberships) {
+            if (member.getRole() == TeamMember.Role.LEADER) {
+                disbandTeam(member);
+            } else {
+                teamMemberRepository.delete(member);
+            }
+        }
+    }
+
+    // > LEADER 탈퇴 = 팀 해산.
+    // > 팀 여권 먼저 삭제 (passport.team_id FK 제약 해제 + 팀 여권 제거).
+    // > district_cover 팀 커버는 team.team_id ON DELETE CASCADE (V15)로 연쇄 삭제.
+    private void disbandTeam(TeamMember leaderMembership) {
+        Long teamId = leaderMembership.getTeam().getId();
+        passportRepository.deleteAllByTeamId(teamId);
+        teamMemberRepository.deleteAllByTeam_Id(teamId);
+        teamRepository.delete(leaderMembership.getTeam());
     }
 
     // > Redis에서 현재 온라인 팀원 위치 조회.

--- a/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
+++ b/src/main/java/com/kauniv/lightrip/global/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.kauniv.lightrip.global.auth.service;
 
+import com.kauniv.lightrip.domain.team.service.TeamService;
 import com.kauniv.lightrip.domain.user.repository.UserRepository;
 import com.kauniv.lightrip.global.auth.dto.TokenResponse;
 import com.kauniv.lightrip.global.auth.entity.Auth;
@@ -26,6 +27,7 @@ public class AuthService {
     private final RedisService redisService;
     private final AuthRepository authRepository;
     private final AppleTokenClient appleTokenClient;
+    private final TeamService teamService;
 
     // > refreshToken을 회전시키므로 새 refreshToken도 함께 반환해야 한다.
     // > 반환하지 않으면 클라이언트가 이전 토큰을 계속 들고 있어 다음 재발급이 REFRESH_TOKEN_MISMATCH로 실패한다.
@@ -60,6 +62,7 @@ public class AuthService {
 
     public void withdraw(Long userId, String accessToken) {
         revokeAppleIfLinked(userId); // CASCADE로 Auth가 같이 삭제되기 전에 revoke용 refreshToken을 먼저 사용
+        teamService.leaveAllTeams(userId); // CASCADE는 team_member 행만 지우므로, 리더면 팀 해산까지 먼저 처리
         userRepository.deleteById(userId); // DB CASCADE가 auth 포함 연관 데이터 전부 삭제
         long expiration = jwtProvider.getExpiration(accessToken);
         if (expiration > 0) {


### PR DESCRIPTION
title: FIX: 팀 생성/탈퇴 데이터 정합성 버그 수정

## 🔗 관련 이슈 (Related Issue)
Closes #190

## 📝 작업 내용
"유저당 팀 1개" 불변식이 코드 어디에도 강제되지 않아 발생한 버그 3건 수정.

1. 팀 리더 탈퇴 시 팀 미정리: `AuthService.withdraw()`가 DB CASCADE에만 의존해 리더 탈퇴 시 `team_member` 행만 지워지고 `team` 자체는 고아로 남던 문제
2. 팀 2개 이상 생성 가능: `create()`/`join()`에 소속 검증이 없던 문제
3. 팀 모드 전환 실패: 버그 2로 인해 `getMyTeam()`의 `findByUser_Id()`(Optional 단일 결과 기대)가 `IncorrectResultSizeDataAccessException`으로 500 나던 문제 (버그 2의 종속 버그, 별도 수정 없이 자연 해소)

**변경 사항**

기존 파일 수정
- `TeamMemberRepository.java` — `existsByUser_Id`, `findAllByUser_Id` 추가
- `TeamService.java` — `create()`/`join()`에 `existsByUser_Id` 소속 검증 추가, `leave()`의 팀 해산 로직을 `disbandTeam()`으로 추출해 `leaveAllTeams()`(회원 탈퇴용)와 공유
- `AuthService.java` — `withdraw()`에서 유저 삭제 전 `teamService.leaveAllTeams(userId)` 호출하도록 `TeamService` 의존성 추가

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.