### PR TITLE
FIX: DB 제약조건에 APPLE 없는 것 수정

### DIFF
--- a/src/main/resources/db/migration/V16__allow_apple_social_type.sql
+++ b/src/main/resources/db/migration/V16__allow_apple_social_type.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.auth DROP CONSTRAINT auth_social_type_check;
+
+ALTER TABLE public.auth ADD CONSTRAINT auth_social_type_check
+    CHECK (((social_type)::text = ANY ((ARRAY['KAKAO'::character varying, 'GOOGLE'::character varying, 'APPLE'::character varying])::text[])));


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
> 예시: Closes #190 

## 📝 작업 내용

>  V16__allow_apple_social_type.sql — `auth.social_type` CHECK 제약조건에 APPLE 추가

## ✅ PR 체크리스트

- [ ] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

