### PR TITLE
FIX: 카카오/Apple 계정 간 이메일 중복 시 신규 가입 차단

### DIFF
--- a/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
+++ b/src/main/java/com/kauniv/lightrip/domain/user/service/UserService.java
@@ -43,10 +43,17 @@ public class UserService {
     }
 
     private Auth createUser(OAuth2UserInfo oAuth2UserInfo, SocialType socialType) {
+        // > 카카오/Apple 등 다른 소셜로 이미 가입된 이메일이면 별개 계정으로 새로 만들지 않고 막음.
+        // > 카카오·Apple 공통 진입점이라 여기 한 곳만 고치면 양방향(카카오→Apple, Apple→카카오) 다 방지됨.
+        String email = oAuth2UserInfo.getEmail();
+        if (email != null && userRepository.findByEmail(email).isPresent()) {
+            throw new BusinessException(ErrorCode.DUPLICATE_SOCIAL_EMAIL);
+        }
+
         User user = userRepository.save(
                 User.builder()
                         .nickname(oAuth2UserInfo.getNickname())
-                        .email(oAuth2UserInfo.getEmail())
+                        .email(email)
                         .build()
         );
 

--- a/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kauniv/lightrip/global/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "A004", "리프레시 토큰이 일치하지 않습니다."),
+    DUPLICATE_SOCIAL_EMAIL(HttpStatus.CONFLICT, "A005", "이미 다른 방법으로 가입된 이메일입니다."),
 
     // ===== User =====
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 사용자입니다."),


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Apple 로그인 QA 중 발견된 후속 버그 수정 (관련: #187)

## 📝 작업 내용
카카오로 가입한 이메일과 동일한 이메일의 Apple 계정으로 로그인하면(또는 반대 방향) 별개의 새 User가 중복 생성되는 문제 수정. `User.email`에 유니크 제약조건이 없어서 발생.

**변경 사항**
기존 파일 수정
- UserService — `createUser()`에서 신규가입 직전 이메일 중복 여부 확인, 이미 다른 소셜로 가입된 이메일이면 `DUPLICATE_SOCIAL_EMAIL` 예외 발생. 카카오·Apple 공통 진입점이라 양방향 다 방지됨.
- ErrorCode — `DUPLICATE_SOCIAL_EMAIL`(`A005`, 409) 추가

## ℹ️ 기타 정보
- 정상적인 재로그인(기존 계정)에는 영향 없음 — `socialId+socialType`로 기존 계정을 먼저 찾고, 못 찾았을 때만(완전 신규가입 시도) 이 체크가 걸림
- 이메일이 null인 경우(소셜에서 이메일 미제공)는 체크 스킵

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다. (전용 이슈 없음 — 필요하면 새로 만들지 결정 필요)
- [ ] 변경 사항에 대한 테스트를 진행했습니다.
